### PR TITLE
Fix white space collapse and default region handling

### DIFF
--- a/src/main/js/html.js
+++ b/src/main/js/html.js
@@ -317,6 +317,8 @@
         var line_head = null;
 
         var lookingForHead = true;
+        
+        var foundBR = false;
 
         for (var i = 0; i <= elist.length; i++) {
 
@@ -324,8 +326,10 @@
              * the rest of the line 
              */
 
-            if (i !== elist.length && elist[i].element.localName === "br")
-                continue;
+            if (i !== elist.length && elist[i].element.localName === "br") {
+                foundBR = true;
+                continue;   
+            }
 
             /* detect new line */
 
@@ -361,13 +365,15 @@
 
                 /* explicit <br> unless already present */
 
-                if (i !== elist.length && line_head !== null && elist[i-1].element.localName !== "br") {
+                if (i !== elist.length && line_head !== null && (!foundBR)) {
 
                     var br = document.createElement("br");
 
                     elist[i].element.parentElement.insertBefore(br, elist[i].element);
 
                     elist.splice(i, 0, {"element": br});
+                    
+                    foundBR = true;
 
                     continue;
 
@@ -382,16 +388,17 @@
                     for (; i < elist.length; i++) {
 
                         if (elist[i].element.getBoundingClientRect().width !== 0) {
+                            addLeftPadding(elist[i].element, elist[i].color, lp);
                             break;
                         }
 
                     }
 
-                    addLeftPadding(elist[i].element, elist[i].color, lp);
-
                 }
 
                 lookingForHead = false;
+                
+                foundBR = false;
 
                 line_head = i;
 

--- a/src/main/js/isd.js
+++ b/src/main/js/isd.js
@@ -85,12 +85,15 @@
 
         var associated_region_id = 'regionID' in elem && elem.regionID !== '' ? elem.regionID : inherited_region_id;
 
-        /* 
-         * immediately prune the element if the associated region is neither the default
-         * region nor the parent region
+        /* prune the element if either:
+         * - the element is not terminal and the associated region is neither the default
+         *   region nor the parent region (this allows children to be associated with a 
+         *   region later on)
+         * - the element is terminal and the associated region is not the parent region
          */
 
-        if (associated_region_id !== region.id && associated_region_id !== '')
+        if (associated_region_id !== region.id &&
+                (('contents' in elem && elem.contents.length === 0) || associated_region_id !== ''))
             return null;
 
         /* create an ISD element */
@@ -286,15 +289,6 @@
             if (c !== null) {
 
                 isd_element.contents.push(c.element);
-                
-                /* associate this element with the child's region, 
-                 * which can only be equal to the default region or
-                 * the parent region
-                 */ 
-                
-                if (c.region_id === region.id) {
-                    associated_region_id = c.region_id;
-                }
 
             }
 
@@ -310,12 +304,6 @@
          }
          */
 
-        /*
-         * prune the element if the associated region is not the parent region
-         */
-        
-        if (associated_region_id !== region.id) return null;
-        
         /* remove styles that are not applicable */
 
         for (var qnameb in isd_element.styleAttrs) {

--- a/src/main/js/isd.js
+++ b/src/main/js/isd.js
@@ -85,15 +85,12 @@
 
         var associated_region_id = 'regionID' in elem && elem.regionID !== '' ? elem.regionID : inherited_region_id;
 
-        /* prune the element if either:
-         * - the element is not terminal and the associated region is neither the default
-         *   region nor the parent region (this allows children to be associated with a 
-         *   region later on)
-         * - the element is terminal and the associated region is not the parent region
+        /* 
+         * immediately prune the element if the associated region is neither the default
+         * region nor the parent region
          */
 
-        if (associated_region_id !== region.id &&
-                (('contents' in elem && elem.contents.length === 0) || associated_region_id !== ''))
+        if (associated_region_id !== region.id && associated_region_id !== '')
             return null;
 
         /* create an ISD element */
@@ -289,6 +286,15 @@
             if (c !== null) {
 
                 isd_element.contents.push(c.element);
+                
+                /* associate this element with the child's region, 
+                 * which can only be equal to the default region or
+                 * the parent region
+                 */ 
+                
+                if (c.region_id === region.id) {
+                    associated_region_id = c.region_id;
+                }
 
             }
 
@@ -304,6 +310,12 @@
          }
          */
 
+        /*
+         * prune the element if the associated region is not the parent region
+         */
+        
+        if (associated_region_id !== region.id) return null;
+        
         /* remove styles that are not applicable */
 
         for (var qnameb in isd_element.styleAttrs) {


### PR DESCRIPTION
White space is now collapsed to a single white space when xml:space="default" (instead of being collapsed to nothing)
Default region is used only if no regions are defined

Closes #21 and closes #22