### PR TITLE
Fix link to the TTML spec

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -14,7 +14,7 @@ documents [1] to HTML5. IMSC1 is a profile of TTML [2] designed for subtitle and
 caption delivery worldwide.
 
 [1] https://www.w3.org/TR/ttml-imsc1/
-[2] https://www.w3.org/TR/ttaf1-dfxp
+[2] http://www.w3.org/TR/ttml1/
 
 A live sample web app using imscJS is available at [3].
 

--- a/README.txt
+++ b/README.txt
@@ -14,7 +14,7 @@ documents [1] to HTML5. IMSC1 is a profile of TTML [2] designed for subtitle and
 caption delivery worldwide.
 
 [1] https://www.w3.org/TR/ttml-imsc1/
-[2] http://www.w3.org/TR/ttml1/
+[2] https://www.w3.org/TR/ttml1/
 
 A live sample web app using imscJS is available at [3].
 


### PR DESCRIPTION
Use the link that's on the TTML1 spec as "latest version" rather than the old "DFXP" one. One slight tweak is to use the https link that the spec's http link redirects to.