### PR TITLE
Fix tts:textEmphasis equals 'before' or 'after'

### DIFF
--- a/src/main/js/html.js
+++ b/src/main/js/html.js
@@ -1531,18 +1531,18 @@
 
                         if (context.bpd === "tb") {
 
-                            pos = (attr === "before") ? "over" : "under";
+                            pos = (attr.position === "before") ? "left over" : "left under";
 
 
                         } else {
 
                             if (context.bpd === "rl") {
 
-                                pos = (attr === "before") ? "right" : "left";
+                                pos = (attr.position === "before") ? "right under" : "left under";
 
                             } else {
 
-                                pos = (attr === "before") ? "left" : "right";
+                                pos = (attr.position === "before") ? "left under" : "right under";
 
                             }
 


### PR DESCRIPTION
Closes #154 