### PR TITLE
Fix rubyReserve=outside in 1-line text blocks

### DIFF
--- a/src/main/js/html.js
+++ b/src/main/js/html.js
@@ -740,7 +740,7 @@
 
             var fs = context.rubyReserve[1].toUsedLength(context.w, context.h) + "px";
 
-            if (context.rubyReserve[0] === "both") {
+            if (context.rubyReserve[0] === "both" || (context.rubyReserve[0] === "outside" && lineList.length == 1)) {
 
                 rt1 = document.createElement("rtc");
                 rt1.style[RUBYPOSITION_PROP] = RUBYPOSITION_ISWK ? "after" : "under";


### PR DESCRIPTION
Closes #180

Deployed at http://sandflow.com/imsc1_1/index.html