### PR TITLE
Fix whitespace trimming around line breaks

### DIFF
--- a/src/main/js/isd.js
+++ b/src/main/js/isd.js
@@ -591,7 +591,7 @@
 
                             elist.splice(l, 1);
                             l--;
-
+                            br_pos--;
                         }
 
                     }


### PR DESCRIPTION
in `isdProcessContentElement`, after removing empty span before `br`, br position value is not updated. 
This makes next "after_br" step to start from the wrong position.

Consider following example:
```xml
<p><span>1 </span><span> </span><span> </span><br/><span> 2</span><span> 3</span><span> 4</span></p>
```
Expected result after trimming is:
`1<br>2 3 4`

Actual result is:
`1<br> 2 34`

Notice how left trimming was applied to " 4" instead of " 2"