### PR TITLE
Improve performance for large input files

### DIFF
--- a/src/main/js/isd.js
+++ b/src/main/js/isd.js
@@ -91,7 +91,11 @@
             }
         }
 
-        body = filter(offset, tt.body);
+        if (tt.body !== null) {
+            body = filter(offset, tt.body);
+        } else {
+            body = null;
+        }
 
         /* rewritten TTML will always have a default - this covers it. because the region is defaulted to "" */
         if (activeRegions.size === 0 && tt.head.layout.regions.hasOwnProperty("")) {

--- a/src/main/js/isd.js
+++ b/src/main/js/isd.js
@@ -59,13 +59,51 @@
 
         };
 
-        /* process regions */
+        /* Filter body contents - Only process what we need within the offset and discard regions not applicable to the content */
+        var body = {};
+        var activeRegions = new Set();
 
-        for (var r in tt.head.layout.regions) {
+        function filter(offset, element) {
+            function offsetFilter(element) {
+                return !(offset < element.begin || offset >= element.end);    
+            }    
+        
+            if (element.contents) {
+                var clone = {};
+                for (var prop in element) {
+                    clone[prop] = element[prop];
+                }
+                clone.contents = [];
 
+                element.contents.filter(offsetFilter).forEach(function (el) {
+                    var filteredElement = filter(offset, el);
+                    if (filteredElement.regionID) {
+                        activeRegions.add(filteredElement.regionID);
+                    }
+        
+                    if (filteredElement !== null) {
+                        clone.contents.push(filteredElement);
+                    }
+                });
+                return clone;
+            } else {
+                return element;
+            }
+        }
+
+        body = filter(offset, tt.body);
+
+        /* rewritten TTML will always have a default - this covers it. because the region is defaulted to "" */
+        if (activeRegions.size === 0 && tt.head.layout.regions.hasOwnProperty("")) {
+            activeRegions.add("");
+        }
+        
+        /* process regions */      
+
+        activeRegions.forEach(function (regionID) {
             /* post-order traversal of the body tree per [construct intermediate document] */
 
-            var c = isdProcessContentElement(tt, offset, tt.head.layout.regions[r], tt.body, null, '', tt.head.layout.regions[r], errorHandler, context);
+            var c = isdProcessContentElement(tt, offset, tt.head.layout.regions[regionID], body, null, '', tt.head.layout.regions[regionID], errorHandler, context);
 
             if (c !== null) {
 
@@ -73,9 +111,7 @@
 
                 isd.contents.push(c.element);
             }
-
-
-        }
+        });
 
         return isd;
     };

--- a/src/main/js/isd.js
+++ b/src/main/js/isd.js
@@ -96,7 +96,9 @@
             if (element.contents) {
                 var clone = {};
                 for (var prop in element) {
-                    clone[prop] = element[prop];
+                    if (element.hasOwnProperty(prop)) {
+                        clone[prop] = element[prop];
+                    }
                 }
                 clone.contents = [];
 

--- a/src/main/js/isd.js
+++ b/src/main/js/isd.js
@@ -123,7 +123,7 @@
         }
 
         /* rewritten TTML will always have a default - this covers it. because the region is defaulted to "" */
-        if (Object.getOwnPropertyNames(activeRegions).length === 1 && activeRegions[""] !== undefined) {
+        if (activeRegions[""] !== undefined) {
             activeRegions[""] = true;
         }
 

--- a/src/main/js/isd.js
+++ b/src/main/js/isd.js
@@ -64,19 +64,17 @@
         var activeRegions = {};
 
         /* gather any regions that might have showBackground="always" and show a background */
-        initialShowBackground = tt.head.styling.initials[imscStyles.byName.showBackground.qname];
-        initialbackgroundColor = tt.head.styling.initials[imscStyles.byName.backgroundColor.qname];
-        initialbackgroundImage = tt.head.styling.initials[imscStyles.byName.backgroundImage.qname];
+        var initialShowBackground = tt.head.styling.initials[imscStyles.byName.showBackground.qname];
+        var initialbackgroundColor = tt.head.styling.initials[imscStyles.byName.backgroundColor.qname];
         for (var layout_child in tt.head.layout.regions)
         {
             if (tt.head.layout.regions.hasOwnProperty(layout_child)) {
-                region = tt.head.layout.regions[layout_child];
-                showBackground = region.styleAttrs[imscStyles.byName.showBackground.qname] || initialShowBackground;
-                backgroundColor = region.styleAttrs[imscStyles.byName.backgroundColor.qname] || initialbackgroundColor;
-                backgroundImage = region.styleAttrs[imscStyles.byName.backgroundImage.qname] || initialbackgroundImage;
+                var region = tt.head.layout.regions[layout_child];
+                var showBackground = region.styleAttrs[imscStyles.byName.showBackground.qname] || initialShowBackground;
+                var backgroundColor = region.styleAttrs[imscStyles.byName.backgroundColor.qname] || initialbackgroundColor;
                 activeRegions[region.id] = (
                     (showBackground === 'always' || showBackground === undefined) &&
-                    (backgroundColor !== undefined || backgroundImage !== undefined) &&
+                    backgroundColor !== undefined &&
                     !(offset < region.begin || offset >= region.end)
                     );
             }


### PR DESCRIPTION
When an input file is large, in some cases it may have both a large number of resulting ISDs _and_ a large number of regions. The ISD processing code currently iterates through all of the body content for every region, even though much of it falls outside the desired ISD's interval. This has been seen to multiply up to impact performance adversely with some real world files.

This pull request modifies `generateISD()` to reduce the number of combinations, by pre-filtering the regions and content to remove anything that falls outside the required interval before iterating through the regions.

Empirically, this has hugely improved the speed. We have not observed any ill-effects, nor thought of any that might arise.