### PR TITLE
mergeSpans requires all elements to be in the linelist

### DIFF
--- a/src/main/js/html.js
+++ b/src/main/js/html.js
@@ -1006,11 +1006,6 @@
 
                 var r = element.getBoundingClientRect();
 
-                /* skip if span is not displayed */
-
-                if (r.height === 0 || r.width === 0)
-                    return;
-
                 var edges = rect2edges(r, context);
 
                 if (llist.length === 0 ||


### PR DESCRIPTION
Fix issue with empty spans or spans that return 0 width due to ligature with previous span