### PR TITLE
Merge spans, simplify applyLinePadding and fix fillLineGap behaviour

### DIFF
--- a/src/main/js/html.js
+++ b/src/main/js/html.js
@@ -416,7 +416,7 @@
 
                     var cc = isd_element.text.charCodeAt(j);
 
-                    if (cc < 0xD800 || cc > 0xDBFF || j === isd_element.text.length-1) {
+                    if (cc < 0xD800 || cc > 0xDBFF || j === isd_element.text.length - 1) {
 
                         /* wrap the character(s) in a span unless it is a high surrogate */
 
@@ -523,7 +523,7 @@
 
                 var par_edges = rect2edges(proc_e.getBoundingClientRect(), context);
 
-                applyFillLineGap(linelist, par_edges.before, par_edges.after, context,proc_e);
+                applyFillLineGap(linelist, par_edges.before, par_edges.after, context, proc_e);
 
                 context.flg = null;
 
@@ -583,7 +583,7 @@
 
             for (var j = 1; j < line.elements.length;) {
 
-                var previous = line.elements[j-1];
+                var previous = line.elements[j - 1];
                 var span = line.elements[j];
 
                 if (spanMerge(previous.node, span.node)) {
@@ -981,9 +981,9 @@
 
                 if (lineList[i-1]) {
 
-                    for (l=0;l<lineList[i-1].elements.length;l++) {
+                    for (l = 0; l < lineList[i - 1].elements.length; l++) {
 
-                        thisNode=lineList[i-1].elements[l];
+                        thisNode=lineList[i - 1].elements[l];
                         padding = s*(frontier-thisNode.after) + "px";
 
                         if (context.bpd === "lr") {
@@ -1009,7 +1009,7 @@
             /* after line */
             if (i < lineList.length) {
 
-                for (l=0;l<lineList[i].elements.length;l++) {
+                for (l = 0; l < lineList[i].elements.length; l++) {
 
                     thisNode = lineList[i].elements[l];
                     padding = s * (thisNode.before - frontier) + "px";

--- a/src/main/js/html.js
+++ b/src/main/js/html.js
@@ -723,7 +723,7 @@
     
                 if (context.ipd === "lr") {
 
-                    se.node.marginLeft = negpadpxlen;
+                    se.node.style.marginLeft = negpadpxlen;
                     se.node.style.paddingLeft = pospadpxlen;
 
                 } else if (context.ipd === "rl") {

--- a/src/main/js/html.js
+++ b/src/main/js/html.js
@@ -676,7 +676,9 @@
                 for (var i = 0; i < second.style.length; i++) {
 
                     var styleName = second.style[i];
-                    if (styleName.indexOf("border") >= 0 || styleName.indexOf("padding") >= 0) {
+                    if (styleName.indexOf("border") >= 0 || 
+                        styleName.indexOf("padding") >= 0 ||
+                        styleName.indexOf("margin") >= 0) {
 
                         first.style[styleName] = second.style[styleName];
 
@@ -720,7 +722,8 @@
                     }
 
                 }
-    
+
+                // Start element
                 if (context.ipd === "lr") {
 
                     se.node.style.marginLeft = negpadpxlen;
@@ -738,6 +741,7 @@
 
                 }
 
+                // End element
                 if (context.ipd === "lr") {
 
                     ee.node.style.marginRight = negpadpxlen;

--- a/src/main/js/html.js
+++ b/src/main/js/html.js
@@ -697,16 +697,30 @@
 
             var l = lineList[i].elements.length;
 
-            var se = lineList[i].elements[lineList[i].start_elem];
-
-            var ee = lineList[i].elements[lineList[i].end_elem];
-
             var pospadpxlen = Math.ceil(lp) + "px";
 
             var negpadpxlen = "-" + Math.ceil(lp) + "px";
 
             if (l !== 0) {
 
+                var se = lineList[i].elements[lineList[i].start_elem];
+
+                var ee = lineList[i].elements[lineList[i].end_elem];
+
+                if (se === ee) {
+
+                    // Check to see if there's any background at all
+                    elementBoundingRect = se.node.getBoundingClientRect();
+                    
+                    if (elementBoundingRect.width == 0 || elementBoundingRect.height == 0) {
+
+                        // There's no background on this line, move on.
+                        continue;
+
+                    }
+
+                }
+    
                 if (context.ipd === "lr") {
 
                     se.node.marginLeft = negpadpxlen;

--- a/src/main/js/html.js
+++ b/src/main/js/html.js
@@ -340,7 +340,6 @@
 
                 }
 
-                context.removePaddingElement=proc_e;
                 context.lp = lp;
             }
         }
@@ -511,19 +510,6 @@
             if (context.lp) {
 
                 applyLinePadding(linelist, context.lp.toUsedLength(context.w, context.h), context);
-
-                if (context.bpd === "tb") {
-
-                    // should this actually be remove?
-                    context.removePaddingElement.style.paddingLeft=0;
-                    context.removePaddingElement.style.paddingRight=0;
-
-                } else {
-
-                    context.removePaddingElement.style.paddingTop=0;
-                    context.removePaddingElement.style.paddingBottom=0;
-
-                }
 
                 context.lp = null;
 


### PR DESCRIPTION
This pull request does several things:
1. Adjacent character spans are merged together into a single span. This means that if e.g. screen readers read the text they do not read each letter separately. It also means that user agents that break ligatures at span boundaries should get an improved rendering behaviour.
2. Simplifies `applyLinePadding` to use `padding` on the line end spans.
3. Fixes fillLineGap, closing #200. Can be used to generate a test image for w3c/imsc-tests#100

When comparing renders of the tests, I got this result:

```Shell
$ python script/refpngcompare.py sandflow/imscJS/renders/imsc1/renders/png/ tests_render/imsc1/renders/png/
/Users/megitn02/Code/sandflow/imscJS/renders/imsc1/renders/png/FillLineGap002/0.000000.png: 0.000225907
/Users/megitn02/Code/sandflow/imscJS/renders/imsc1/renders/png/FillLineGap004/0.000000.png: 0.000468971
/Users/megitn02/Code/sandflow/imscJS/renders/imsc1/renders/png/FillLineGap003/0.000000.png: 0.000728906
/Users/megitn02/Code/sandflow/imscJS/renders/imsc1/renders/png/FillLineGap003/35.000000.png: 0.00154229
/Users/megitn02/Code/sandflow/imscJS/renders/imsc1/renders/png/FillLineGap003/30.000000.png: 0.00171816
/Users/megitn02/Code/sandflow/imscJS/renders/imsc1/renders/png/FillLineGap003/5.000000.png: 0.000773408
/Users/megitn02/Code/sandflow/imscJS/renders/imsc1/renders/png/FillLineGap003/20.000000.png: 0.00144757
/Users/megitn02/Code/sandflow/imscJS/renders/imsc1/renders/png/FillLineGap003/25.000000.png: 0.00014814
/Users/megitn02/Code/sandflow/imscJS/renders/imsc1/renders/png/FillLineGap003/15.000000.png: 0.000651107
/Users/megitn02/Code/sandflow/imscJS/renders/imsc1/renders/png/FillLineGap003/10.000000.png: 0.00137215
/Users/megitn02/Code/sandflow/imscJS/renders/imsc1/renders/png/LinePadding005/0.000000.png: 0.0062804
/Users/megitn02/Code/sandflow/imscJS/renders/imsc1/renders/png/linePadding3/0.000000.png: 0.00014617
/Users/megitn02/Code/sandflow/imscJS/renders/imsc1/renders/png/FillLineGap001/0.000000.png: 0.000507626
/Users/megitn02/Code/sandflow/imscJS/renders/imsc1/renders/png/DisplayAlign004/0.000000.png: 0.000578269
$ python script/refpngcompare.py ~/Code/sandflow/imscJS/renders/imsc1.1/renders/png/ tests_render/imsc1.1/renders/png/
/Users/megitn02/Code/sandflow/imscJS/renders/imsc1.1/renders/png/shear001/0.000000.png: 0.000475705
/Users/megitn02/Code/sandflow/imscJS/renders/imsc1.1/renders/png/shear001/5.000000.png: 0.000519006
/Users/megitn02/Code/sandflow/imscJS/renders/imsc1.1/renders/png/shear001/2.000000.png: 0.000521545
/Users/megitn02/Code/sandflow/imscJS/renders/imsc1.1/renders/png/shear001/4.000000.png: 0.000490956
/Users/megitn02/Code/sandflow/imscJS/renders/imsc1.1/renders/png/shear001/1.000000.png: 0.000475886
/Users/megitn02/Code/sandflow/imscJS/renders/imsc1.1/renders/png/shear001/3.000000.png: 0.00047467
```

On inspection, I couldn't see anything that would be especially worrisome about these diffs. The largest diff, for `LinePadding005/0.000000.png` is mainly caused by the correct rendering of ligatures in the Arabic text, demonstrating a benefit of this pull request.