### PR TITLE
Externaldom

### DIFF
--- a/src/main/js/html.js
+++ b/src/main/js/html.js
@@ -1821,15 +1821,20 @@
     }
 
     /* CSS property names */
+    try { // try these, but if we're not in the browser, window does not exist.
+      var RUBYPOSITION_ISWK = "webkitRubyPosition" in window.getComputedStyle(document.documentElement);
 
-    var RUBYPOSITION_ISWK = "webkitRubyPosition" in window.getComputedStyle(document.documentElement);
+      var RUBYPOSITION_PROP = RUBYPOSITION_ISWK ? "webkitRubyPosition" : "rubyPosition";
 
-    var RUBYPOSITION_PROP = RUBYPOSITION_ISWK ? "webkitRubyPosition" : "rubyPosition";
+      var TEXTEMPHASISSTYLE_PROP = "webkitTextEmphasisStyle" in window.getComputedStyle(document.documentElement) ? "webkitTextEmphasisStyle" : "textEmphasisStyle";
 
-    var TEXTEMPHASISSTYLE_PROP = "webkitTextEmphasisStyle" in window.getComputedStyle(document.documentElement) ? "webkitTextEmphasisStyle" : "textEmphasisStyle";
-
-    var TEXTEMPHASISPOSITION_PROP = "webkitTextEmphasisPosition" in window.getComputedStyle(document.documentElement) ? "webkitTextEmphasisPosition" : "textEmphasisPosition";
-
+      var TEXTEMPHASISPOSITION_PROP = "webkitTextEmphasisPosition" in window.getComputedStyle(document.documentElement) ? "webkitTextEmphasisPosition" : "textEmphasisPosition";
+    } catch (e){
+      var RUBYPOSITION_ISWK = false;
+      var RUBYPOSITION_PROP = "rubyPosition";
+      var TEXTEMPHASISSTYLE_PROP = "textEmphasisStyle";
+      var TEXTEMPHASISPOSITION_PROP = "textEmphasisPosition";
+    }
     /* error utilities */
 
     function reportError(errorHandler, msg) {

--- a/src/main/js/html.js
+++ b/src/main/js/html.js
@@ -1838,24 +1838,21 @@
         STYLMAP_BY_QNAME[STYLING_MAP_DEFS[i].qname] = STYLING_MAP_DEFS[i];
     }
 
-    /* CSS property names */
+    // if no browser window/document, then default, not break;
+    var RUBYPOSITION_ISWK = false;
+    var RUBYPOSITION_PROP = "rubyPosition";
+    var TEXTEMPHASISSTYLE_PROP = "textEmphasisStyle";
+    var TEXTEMPHASISPOSITION_PROP = "textEmphasisPosition";
+
     try {
-      var RUBYPOSITION_ISWK = "webkitRubyPosition" in window.getComputedStyle(document.documentElement);
+      RUBYPOSITION_ISWK = "webkitRubyPosition" in window.getComputedStyle(document.documentElement);
 
-      var RUBYPOSITION_PROP = RUBYPOSITION_ISWK ? "webkitRubyPosition" : "rubyPosition";
+      RUBYPOSITION_PROP = RUBYPOSITION_ISWK ? "webkitRubyPosition" : "rubyPosition";
 
-      var TEXTEMPHASISSTYLE_PROP = "webkitTextEmphasisStyle" in window.getComputedStyle(document.documentElement) ? "webkitTextEmphasisStyle" : "textEmphasisStyle";
+      TEXTEMPHASISSTYLE_PROP = "webkitTextEmphasisStyle" in window.getComputedStyle(document.documentElement) ? "webkitTextEmphasisStyle" : "textEmphasisStyle";
 
-      var TEXTEMPHASISPOSITION_PROP = "webkitTextEmphasisPosition" in window.getComputedStyle(document.documentElement) ? "webkitTextEmphasisPosition" : "textEmphasisPosition";
+      TEXTEMPHASISPOSITION_PROP = "webkitTextEmphasisPosition" in window.getComputedStyle(document.documentElement) ? "webkitTextEmphasisPosition" : "textEmphasisPosition";
     } catch (e){
-      // if no browser window/document, then default, not break;
-      var RUBYPOSITION_ISWK = false;
-      
-      var RUBYPOSITION_PROP = "rubyPosition";
-      
-      var TEXTEMPHASISSTYLE_PROP = "textEmphasisStyle";
-      
-      var TEXTEMPHASISPOSITION_PROP = "textEmphasisPosition";
     }
     /* error utilities */
 

--- a/src/main/js/html.js
+++ b/src/main/js/html.js
@@ -78,9 +78,20 @@
             displayForcedOnlyMode,
             errorHandler,
             previousISDState,
-            enableRollUp
+            enableRollUp,
+            dom_document
             ) {
 
+        // if alternative dom document functions wanted, use it
+        if (dom_document){
+           imscHTML.document = dom_document;
+           imscHTML.Node = dom_document.Node;
+        } else {
+           imscHTML.document = document;
+           imscHTML.Node = Node;
+        }
+        var document = imscHTML.document;
+            
         /* maintain aspect ratio if specified */
 
         var height = eheight || element.clientHeight;
@@ -155,6 +166,7 @@
     function processElement(context, dom_parent, isd_element, isd_parent) {
 
         var e;
+        var document = imscHTML.document;
 
         if (isd_element.kind === 'region') {
 
@@ -762,6 +774,7 @@
     }
 
     function applyMultiRowAlign(lineList) {
+        var document = imscHTML.document;
 
         /* apply an explicit br to all but the last line */
 
@@ -871,6 +884,7 @@
     }
 
     function applyRubyReserve(lineList, context) {
+        var document = imscHTML.document;
 
         for (var i = 0; i < lineList.length; i++) {
 
@@ -1102,6 +1116,8 @@
             return;
 
         }
+        
+        var Node = imscHTML.Node;
 
         var curbgcolor = element.style.backgroundColor || bgcolor;
 

--- a/src/main/js/main.js
+++ b/src/main/js/main.js
@@ -27,3 +27,4 @@
 exports.generateISD = require('./isd').generateISD;
 exports.fromXML = require('./doc').fromXML;
 exports.renderHTML = require('./html').render;
+exports.styles = require('./styles');


### PR DESCRIPTION
re-submitting a 2019 request.
1/ allows imscJS doc.js to be used in NodeJS by defaulting things dependent on browser 'window' and 'document'.
2/ allows options = {document: someotherdom } to be passed into imscHTML.render so that the render function can be used without the browser.
3/ exposes styles in main.js - if NOT using imscHTML to render the ISDs, then you need styles to interpret them....
