### PR TITLE
Modern ES2015+ syntax and ESModules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,33 @@
+module.exports = {
+    "env": {
+        "browser": true,
+        "commonjs": true,
+        "es2021": true,
+        "node": true
+    },
+    "extends": "eslint:recommended",
+    "parserOptions": {
+        "ecmaVersion": "latest"
+    },
+    globals: {
+        'sax' : "writable"
+    },
+    "rules": {
+        "indent": [
+            "error",
+            4
+        ],
+        "linebreak-style": [
+            "error",
+            "unix"
+        ],
+        "quotes": [
+            "error",
+            "single"
+        ],
+        "semi": [
+            "error",
+            "always"
+        ]
+    }
+};

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules/
 nbproject/private
 ga.js
 .vscode/
+.idea/

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,96 +1,124 @@
+const babelConfig = require('./babel.config');
+
 module.exports = function (grunt) {
 
     grunt.initConfig({
 
-        properties: grunt.file.readJSON('properties.json'),
+            properties: grunt.file.readJSON('properties.json'),
 
-        pkg: grunt.file.readJSON('package.json'),
+            pkg: grunt.file.readJSON('package.json'),
 
-        clean: ['<%= properties.webappBuildDir %>', '<%= properties.umdBuildDir %>'],
+            clean: ['<%= properties.webappBuildDir %>', '<%= properties.umdBuildDir %>'],
 
-        sync: {
-            all: {
-                files:
-                    [
-                        // copy tests
-                        { expand: true, cwd: '<%= properties.webappTestDir %>', src: '**', dest: '<%= properties.webappBuildDir %>' },
+            sync: {
+                all: {
+                    files:
+                        [
+                            // copy tests
+                            {
+                                expand: true,
+                                cwd: '<%= properties.webappTestDir %>',
+                                src: '**',
+                                dest: '<%= properties.webappBuildDir %>'
+                            },
 
-                        // copy tests resources
-                        { expand: true, cwd: '<%= properties.unitTestsResourcesDir %>', src: 'imsc-tests/imsc1/ttml/**', dest: '<%= properties.webappBuildDir %>' },
-                        { expand: true, cwd: '<%= properties.unitTestsResourcesDir %>', src: 'imsc-tests/imsc1/tests.json', dest: '<%= properties.webappBuildDir %>' },
-                        { expand: true, cwd: '<%= properties.unitTestsResourcesDir %>', src: 'imsc-tests/imsc1_1/ttml/**', dest: '<%= properties.webappBuildDir %>' },
-                        { expand: true, cwd: '<%= properties.unitTestsResourcesDir %>', src: 'imsc-tests/imsc1_1/tests.json', dest: '<%= properties.webappBuildDir %>' },
-                        { expand: true, cwd: '<%= properties.unitTestsResourcesDir %>', src: 'unit-tests/**', dest: '<%= properties.webappBuildDir %>' }
-                    ]
-            },
+                            // copy tests resources
+                            {
+                                expand: true,
+                                cwd: '<%= properties.unitTestsResourcesDir %>',
+                                src: 'imsc-tests/imsc1/ttml/**',
+                                dest: '<%= properties.webappBuildDir %>'
+                            },
+                            {
+                                expand: true,
+                                cwd: '<%= properties.unitTestsResourcesDir %>',
+                                src: 'imsc-tests/imsc1/tests.json',
+                                dest: '<%= properties.webappBuildDir %>'
+                            },
+                            {
+                                expand: true,
+                                cwd: '<%= properties.unitTestsResourcesDir %>',
+                                src: 'imsc-tests/imsc1_1/ttml/**',
+                                dest: '<%= properties.webappBuildDir %>'
+                            },
+                            {
+                                expand: true,
+                                cwd: '<%= properties.unitTestsResourcesDir %>',
+                                src: 'imsc-tests/imsc1_1/tests.json',
+                                dest: '<%= properties.webappBuildDir %>'
+                            },
+                            {
+                                expand: true,
+                                cwd: '<%= properties.unitTestsResourcesDir %>',
+                                src: 'unit-tests/**',
+                                dest: '<%= properties.webappBuildDir %>'
+                            }
+                        ]
+                },
 
-            release: {
-                src: '<%= properties.umdBuildDir %>/<%= properties.umdMinName %>',
-                dest: '<%= properties.webappBuildDir %>/libs/imsc.js'
-            },
+                release: {
+                    src: '<%= properties.umdBuildDir %>/<%= properties.umdMinName %>',
+                    dest: '<%= properties.webappBuildDir %>/libs/imsc.js'
+                },
 
-            debug: {
-                src: '<%= properties.umdBuildDir %>/<%= properties.umdDebugName %>',
-                dest: '<%= properties.webappBuildDir %>/libs/imsc.js'
-            }
-        },
-
-        npmcopy: {
-            default: {
-                files: {
-                    '<%= properties.webappBuildDir %>/libs/': [
-                        'sax:main',
-                        'qunit-assert-close:main',
-                        'qunitjs:main',
-                        'filesaver.js-npm:main',
-                        'jszip/dist/jszip.js'
-                    ]
+                debug: {
+                    src: '<%= properties.umdBuildDir %>/<%= properties.umdDebugName %>',
+                    dest: '<%= properties.webappBuildDir %>/libs/imsc.js'
                 }
-            }
-        },
+            },
 
-        browserify: [
-            {
-                src: "<%= pkg.main %>",
-                dest: "<%= properties.umdBuildDir %>/<%= properties.umdDebugName %>",
-                options: {
-                    exclude: ["sax"],
-                    browserifyOptions: {
-                        standalone: 'imsc'
+            npmcopy: {
+                default: {
+                    files: {
+                        '<%= properties.webappBuildDir %>/libs/': [
+                            'sax:main',
+                            'qunit-assert-close:main',
+                            'qunitjs:main',
+                            'filesaver.js-npm:main',
+                            'jszip/dist/jszip.js'
+                        ]
                     }
                 }
             },
-            {
-                src: "<%= pkg.main %>",
-                dest: "<%= properties.umdBuildDir %>/<%= properties.umdAllDebugName %>",
-                options: {
-                    browserifyOptions: {
-                        standalone: 'imsc'
+
+            browserify: [
+                {
+                    src: "<%= pkg.main %>",
+                    dest: "<%= properties.umdBuildDir %>/<%= properties.umdDebugName %>",
+                    options: {
+                        transform: [["babelify", babelConfig]],
+                        exclude: ["sax"],
+                        browserifyOptions: {
+                            standalone: 'imsc'
+                        }
+                    }
+                },
+                {
+                    src: "<%= pkg.main %>",
+                    dest: "<%= properties.umdBuildDir %>/<%= properties.umdAllDebugName %>",
+                    options: {
+                        transform: [["babelify", babelConfig]],
+                        browserifyOptions: {
+                            standalone: 'imsc'
+                        }
                     }
                 }
-            }
-        ],
+            ],
 
-        jshint: {
-            'default': {
-                src: "src/main/js",
-                options: {
-                    "-W032": true
-                }
-            }
-        },
+            eslint: {
+                target: "src/main",
+            },
 
-        exec: {
-            minify:
-            {
-                cmd: [
-                    "npx google-closure-compiler --js=<%= properties.umdBuildDir %>/<%= properties.umdAllDebugName %> --js_output_file=<%= properties.umdBuildDir %>/<%= properties.umdAllMinName %>",
-                    "npx google-closure-compiler --js=<%= properties.umdBuildDir %>/<%= properties.umdDebugName %> --js_output_file=<%= properties.umdBuildDir %>/<%= properties.umdMinName %>"
-                ].join("&&")
+            exec: {
+                minify:
+                    {
+                        cmd: [
+                            "npx google-closure-compiler --js=<%= properties.umdBuildDir %>/<%= properties.umdAllDebugName %> --js_output_file=<%= properties.umdBuildDir %>/<%= properties.umdAllMinName %>",
+                            "npx google-closure-compiler --js=<%= properties.umdBuildDir %>/<%= properties.umdDebugName %> --js_output_file=<%= properties.umdBuildDir %>/<%= properties.umdMinName %>"
+                        ].join("&&")
+                    }
             }
         }
-    }
-
     );
 
     grunt.loadNpmTasks('grunt-contrib-clean');
@@ -99,15 +127,19 @@ module.exports = function (grunt) {
 
     grunt.loadNpmTasks('grunt-browserify');
 
-    grunt.loadNpmTasks('grunt-contrib-jshint');
+    grunt.loadNpmTasks('grunt-babel');
+
+    grunt.loadNpmTasks('grunt-eslint');
 
     grunt.loadNpmTasks('grunt-sync');
 
     grunt.loadNpmTasks('grunt-exec');
 
-    grunt.registerTask('build:release', ['jshint', 'browserify', 'exec:minify', 'sync:all', 'sync:release', 'npmcopy']);
+    // Register tasks
 
-    grunt.registerTask('build:debug', ['jshint', 'browserify', 'exec:minify', 'sync:all', 'sync:debug', 'npmcopy']);
+    grunt.registerTask('build:release', ['eslint', 'browserify', 'exec:minify', 'sync:all', 'sync:release', 'npmcopy']);
+
+    grunt.registerTask('build:debug', ['eslint', 'browserify', 'exec:minify', 'sync:all', 'sync:debug', 'npmcopy']);
 
     grunt.registerTask('build', ['build:debug']);
 

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+    "presets": ["@babel/preset-env"],
+    "plugins": ["@babel/plugin-transform-modules-umd", {
+    }],
+    "include" : [
+        "@babel/plugin-transform-classes"
+    ],
+    "moduleId": "imsc"
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,8037 @@
+{
+    "name": "imsc",
+    "version": "1.1.3",
+    "lockfileVersion": 1,
+    "requires": true,
+    "dependencies": {
+        "@ampproject/remapping": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.1.2.tgz",
+            "integrity": "sha512-hoyByceqwKirw7w3Z7gnIIZC3Wx3J484Y3L/cMpXFbr7d9ZQj2mODrirNzcJa+SM3UlpWXYvKV4RlRpFXlWgXg==",
+            "dev": true,
+            "requires": {
+                "@jridgewell/trace-mapping": "^0.3.0"
+            }
+        },
+        "@babel/cli": {
+            "version": "7.17.6",
+            "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.17.6.tgz",
+            "integrity": "sha512-l4w608nsDNlxZhiJ5tE3DbNmr61fIKMZ6fTBo171VEFuFMIYuJ3mHRhTLEkKKyvx2Mizkkv/0a8OJOnZqkKYNA==",
+            "dev": true,
+            "requires": {
+                "@jridgewell/trace-mapping": "^0.3.4",
+                "@nicolo-ribaudo/chokidar-2": "2.1.8-no-fsevents.3",
+                "chokidar": "^3.4.0",
+                "commander": "^4.0.1",
+                "convert-source-map": "^1.1.0",
+                "fs-readdir-recursive": "^1.1.0",
+                "glob": "^7.0.0",
+                "make-dir": "^2.1.0",
+                "slash": "^2.0.0",
+                "source-map": "^0.5.0"
+            },
+            "dependencies": {
+                "commander": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+                    "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/code-frame": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.7.tgz",
+            "integrity": "sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==",
+            "dev": true,
+            "requires": {
+                "@babel/highlight": "^7.16.7"
+            }
+        },
+        "@babel/compat-data": {
+            "version": "7.17.0",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.17.0.tgz",
+            "integrity": "sha512-392byTlpGWXMv4FbyWw3sAZ/FrW/DrwqLGXpy0mbyNe9Taqv1mg9yON5/o0cnr8XYCkFTZbC1eV+c+LAROgrng==",
+            "dev": true
+        },
+        "@babel/core": {
+            "version": "7.17.5",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.17.5.tgz",
+            "integrity": "sha512-/BBMw4EvjmyquN5O+t5eh0+YqB3XXJkYD2cjKpYtWOfFy4lQ4UozNSmxAcWT8r2XtZs0ewG+zrfsqeR15i1ajA==",
+            "dev": true,
+            "requires": {
+                "@ampproject/remapping": "^2.1.0",
+                "@babel/code-frame": "^7.16.7",
+                "@babel/generator": "^7.17.3",
+                "@babel/helper-compilation-targets": "^7.16.7",
+                "@babel/helper-module-transforms": "^7.16.7",
+                "@babel/helpers": "^7.17.2",
+                "@babel/parser": "^7.17.3",
+                "@babel/template": "^7.16.7",
+                "@babel/traverse": "^7.17.3",
+                "@babel/types": "^7.17.0",
+                "convert-source-map": "^1.7.0",
+                "debug": "^4.1.0",
+                "gensync": "^1.0.0-beta.2",
+                "json5": "^2.1.2",
+                "semver": "^6.3.0"
+            },
+            "dependencies": {
+                "convert-source-map": {
+                    "version": "1.8.0",
+                    "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
+                    "integrity": "sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==",
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "~5.1.1"
+                    }
+                },
+                "debug": {
+                    "version": "4.3.3",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+                    "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.1.2"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                    "dev": true
+                },
+                "safe-buffer": {
+                    "version": "5.1.2",
+                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+                    "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+                    "dev": true
+                },
+                "semver": {
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/generator": {
+            "version": "7.17.3",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.3.tgz",
+            "integrity": "sha512-+R6Dctil/MgUsZsZAkYgK+ADNSZzJRRy0TvY65T71z/CR854xHQ1EweBYXdfT+HNeN7w0cSJJEzgxZMv40pxsg==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.17.0",
+                "jsesc": "^2.5.1",
+                "source-map": "^0.5.0"
+            }
+        },
+        "@babel/helper-annotate-as-pure": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.16.7.tgz",
+            "integrity": "sha512-s6t2w/IPQVTAET1HitoowRGXooX8mCgtuP5195wD/QJPV6wYjpujCGF7JuMODVX2ZAJOf1GT6DT9MHEZvLOFSw==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.16.7"
+            }
+        },
+        "@babel/helper-builder-binary-assignment-operator-visitor": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.16.7.tgz",
+            "integrity": "sha512-C6FdbRaxYjwVu/geKW4ZeQ0Q31AftgRcdSnZ5/jsH6BzCJbtvXvhpfkbkThYSuutZA7nCXpPR6AD9zd1dprMkA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-explode-assignable-expression": "^7.16.7",
+                "@babel/types": "^7.16.7"
+            }
+        },
+        "@babel/helper-call-delegate": {
+            "version": "7.0.0-beta.53",
+            "resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.0.0-beta.53.tgz",
+            "integrity": "sha1-ld6Lq9A/nmz08rVkoDhwjBOP/jE=",
+            "dev": true,
+            "requires": {
+                "@babel/helper-hoist-variables": "7.0.0-beta.53",
+                "@babel/traverse": "7.0.0-beta.53",
+                "@babel/types": "7.0.0-beta.53"
+            },
+            "dependencies": {
+                "@babel/code-frame": {
+                    "version": "7.0.0-beta.53",
+                    "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.53.tgz",
+                    "integrity": "sha1-mA0VYLhjV1v1o3eSUDfgEy71kh4=",
+                    "dev": true,
+                    "requires": {
+                        "@babel/highlight": "7.0.0-beta.53"
+                    }
+                },
+                "@babel/generator": {
+                    "version": "7.0.0-beta.53",
+                    "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.53.tgz",
+                    "integrity": "sha1-uMrXLFcr4yNK/94ivm2sxCUOA0s=",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "7.0.0-beta.53",
+                        "jsesc": "^2.5.1",
+                        "lodash": "^4.17.5",
+                        "source-map": "^0.5.0",
+                        "trim-right": "^1.0.1"
+                    }
+                },
+                "@babel/helper-function-name": {
+                    "version": "7.0.0-beta.53",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.53.tgz",
+                    "integrity": "sha1-USgEro6cvOVDHr6hnkdijC7WU/I=",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-get-function-arity": "7.0.0-beta.53",
+                        "@babel/template": "7.0.0-beta.53",
+                        "@babel/types": "7.0.0-beta.53"
+                    }
+                },
+                "@babel/helper-get-function-arity": {
+                    "version": "7.0.0-beta.53",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.53.tgz",
+                    "integrity": "sha1-3tiKsp+bHbYch9G7jTijXdp3neY=",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "7.0.0-beta.53"
+                    }
+                },
+                "@babel/helper-hoist-variables": {
+                    "version": "7.0.0-beta.53",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.0.0-beta.53.tgz",
+                    "integrity": "sha1-TCfjuHP6CcWtbpPrQHBMIA+EE3w=",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "7.0.0-beta.53"
+                    }
+                },
+                "@babel/helper-split-export-declaration": {
+                    "version": "7.0.0-beta.53",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.53.tgz",
+                    "integrity": "sha1-rvVLix+ZYW6jfJhHhxajeAJjMls=",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "7.0.0-beta.53"
+                    }
+                },
+                "@babel/highlight": {
+                    "version": "7.0.0-beta.53",
+                    "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.53.tgz",
+                    "integrity": "sha1-9OlS2tF4fSBeGI0+OEzc5JyjaPs=",
+                    "dev": true,
+                    "requires": {
+                        "chalk": "^2.0.0",
+                        "esutils": "^2.0.2",
+                        "js-tokens": "^3.0.0"
+                    }
+                },
+                "@babel/parser": {
+                    "version": "7.0.0-beta.53",
+                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-beta.53.tgz",
+                    "integrity": "sha1-H0XrYXv5Rj1IKywE00nZ5O2/SJI=",
+                    "dev": true
+                },
+                "@babel/template": {
+                    "version": "7.0.0-beta.53",
+                    "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.53.tgz",
+                    "integrity": "sha1-MyIpCQDQsYewpxdDgeHzu3EFDS4=",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "7.0.0-beta.53",
+                        "@babel/parser": "7.0.0-beta.53",
+                        "@babel/types": "7.0.0-beta.53",
+                        "lodash": "^4.17.5"
+                    }
+                },
+                "@babel/traverse": {
+                    "version": "7.0.0-beta.53",
+                    "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.53.tgz",
+                    "integrity": "sha1-ANMs2NC1j0wB0xFXvmIsZigm00Q=",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "7.0.0-beta.53",
+                        "@babel/generator": "7.0.0-beta.53",
+                        "@babel/helper-function-name": "7.0.0-beta.53",
+                        "@babel/helper-split-export-declaration": "7.0.0-beta.53",
+                        "@babel/parser": "7.0.0-beta.53",
+                        "@babel/types": "7.0.0-beta.53",
+                        "debug": "^3.1.0",
+                        "globals": "^11.1.0",
+                        "invariant": "^2.2.0",
+                        "lodash": "^4.17.5"
+                    }
+                },
+                "@babel/types": {
+                    "version": "7.0.0-beta.53",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.53.tgz",
+                    "integrity": "sha1-GaRhwNpRVZXftnQLS0Xce7Dms3U=",
+                    "dev": true,
+                    "requires": {
+                        "esutils": "^2.0.2",
+                        "lodash": "^4.17.5",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                },
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^1.9.0"
+                    }
+                },
+                "chalk": {
+                    "version": "2.4.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+                    "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "1.9.3",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+                    "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "1.1.3"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+                    "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+                    "dev": true
+                },
+                "debug": {
+                    "version": "3.2.7",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+                    "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "has-flag": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+                    "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+                    "dev": true
+                },
+                "js-tokens": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+                    "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+                    "dev": true
+                },
+                "ms": {
+                    "version": "2.1.3",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+                    "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "5.5.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                }
+            }
+        },
+        "@babel/helper-compilation-targets": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.16.7.tgz",
+            "integrity": "sha512-mGojBwIWcwGD6rfqgRXVlVYmPAv7eOpIemUG3dGnDdCY4Pae70ROij3XmfrH6Fa1h1aiDylpglbZyktfzyo/hA==",
+            "dev": true,
+            "requires": {
+                "@babel/compat-data": "^7.16.4",
+                "@babel/helper-validator-option": "^7.16.7",
+                "browserslist": "^4.17.5",
+                "semver": "^6.3.0"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/helper-create-class-features-plugin": {
+            "version": "7.17.6",
+            "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.17.6.tgz",
+            "integrity": "sha512-SogLLSxXm2OkBbSsHZMM4tUi8fUzjs63AT/d0YQIzr6GSd8Hxsbk2KYDX0k0DweAzGMj/YWeiCsorIdtdcW8Eg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-annotate-as-pure": "^7.16.7",
+                "@babel/helper-environment-visitor": "^7.16.7",
+                "@babel/helper-function-name": "^7.16.7",
+                "@babel/helper-member-expression-to-functions": "^7.16.7",
+                "@babel/helper-optimise-call-expression": "^7.16.7",
+                "@babel/helper-replace-supers": "^7.16.7",
+                "@babel/helper-split-export-declaration": "^7.16.7"
+            }
+        },
+        "@babel/helper-create-regexp-features-plugin": {
+            "version": "7.17.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.17.0.tgz",
+            "integrity": "sha512-awO2So99wG6KnlE+TPs6rn83gCz5WlEePJDTnLEqbchMVrBeAujURVphRdigsk094VhvZehFoNOihSlcBjwsXA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-annotate-as-pure": "^7.16.7",
+                "regexpu-core": "^5.0.1"
+            }
+        },
+        "@babel/helper-define-map": {
+            "version": "7.0.0-beta.53",
+            "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.0.0-beta.53.tgz",
+            "integrity": "sha1-SOniJlRTeHl1BD76qx7a0jnqlpU=",
+            "dev": true,
+            "requires": {
+                "@babel/helper-function-name": "7.0.0-beta.53",
+                "@babel/types": "7.0.0-beta.53",
+                "lodash": "^4.17.5"
+            },
+            "dependencies": {
+                "@babel/code-frame": {
+                    "version": "7.0.0-beta.53",
+                    "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.53.tgz",
+                    "integrity": "sha1-mA0VYLhjV1v1o3eSUDfgEy71kh4=",
+                    "dev": true,
+                    "requires": {
+                        "@babel/highlight": "7.0.0-beta.53"
+                    }
+                },
+                "@babel/helper-function-name": {
+                    "version": "7.0.0-beta.53",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.53.tgz",
+                    "integrity": "sha1-USgEro6cvOVDHr6hnkdijC7WU/I=",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-get-function-arity": "7.0.0-beta.53",
+                        "@babel/template": "7.0.0-beta.53",
+                        "@babel/types": "7.0.0-beta.53"
+                    }
+                },
+                "@babel/helper-get-function-arity": {
+                    "version": "7.0.0-beta.53",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.53.tgz",
+                    "integrity": "sha1-3tiKsp+bHbYch9G7jTijXdp3neY=",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "7.0.0-beta.53"
+                    }
+                },
+                "@babel/highlight": {
+                    "version": "7.0.0-beta.53",
+                    "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.53.tgz",
+                    "integrity": "sha1-9OlS2tF4fSBeGI0+OEzc5JyjaPs=",
+                    "dev": true,
+                    "requires": {
+                        "chalk": "^2.0.0",
+                        "esutils": "^2.0.2",
+                        "js-tokens": "^3.0.0"
+                    }
+                },
+                "@babel/parser": {
+                    "version": "7.0.0-beta.53",
+                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-beta.53.tgz",
+                    "integrity": "sha1-H0XrYXv5Rj1IKywE00nZ5O2/SJI=",
+                    "dev": true
+                },
+                "@babel/template": {
+                    "version": "7.0.0-beta.53",
+                    "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.53.tgz",
+                    "integrity": "sha1-MyIpCQDQsYewpxdDgeHzu3EFDS4=",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "7.0.0-beta.53",
+                        "@babel/parser": "7.0.0-beta.53",
+                        "@babel/types": "7.0.0-beta.53",
+                        "lodash": "^4.17.5"
+                    }
+                },
+                "@babel/types": {
+                    "version": "7.0.0-beta.53",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.53.tgz",
+                    "integrity": "sha1-GaRhwNpRVZXftnQLS0Xce7Dms3U=",
+                    "dev": true,
+                    "requires": {
+                        "esutils": "^2.0.2",
+                        "lodash": "^4.17.5",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                },
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^1.9.0"
+                    }
+                },
+                "chalk": {
+                    "version": "2.4.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+                    "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "1.9.3",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+                    "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "1.1.3"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+                    "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+                    "dev": true
+                },
+                "has-flag": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+                    "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+                    "dev": true
+                },
+                "js-tokens": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+                    "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "5.5.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                }
+            }
+        },
+        "@babel/helper-define-polyfill-provider": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.3.1.tgz",
+            "integrity": "sha512-J9hGMpJQmtWmj46B3kBHmL38UhJGhYX7eqkcq+2gsstyYt341HmPeWspihX43yVRA0mS+8GGk2Gckc7bY/HCmA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-compilation-targets": "^7.13.0",
+                "@babel/helper-module-imports": "^7.12.13",
+                "@babel/helper-plugin-utils": "^7.13.0",
+                "@babel/traverse": "^7.13.0",
+                "debug": "^4.1.1",
+                "lodash.debounce": "^4.0.8",
+                "resolve": "^1.14.2",
+                "semver": "^6.1.2"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "4.3.3",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+                    "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.1.2"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                    "dev": true
+                },
+                "semver": {
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/helper-environment-visitor": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.16.7.tgz",
+            "integrity": "sha512-SLLb0AAn6PkUeAfKJCCOl9e1R53pQlGAfc4y4XuMRZfqeMYLE0dM1LMhqbGAlGQY0lfw5/ohoYWAe9V1yibRag==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.16.7"
+            }
+        },
+        "@babel/helper-explode-assignable-expression": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.16.7.tgz",
+            "integrity": "sha512-KyUenhWMC8VrxzkGP0Jizjo4/Zx+1nNZhgocs+gLzyZyB8SHidhoq9KK/8Ato4anhwsivfkBLftky7gvzbZMtQ==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.16.7"
+            }
+        },
+        "@babel/helper-function-name": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.16.7.tgz",
+            "integrity": "sha512-QfDfEnIUyyBSR3HtrtGECuZ6DAyCkYFp7GHl75vFtTnn6pjKeK0T1DB5lLkFvBea8MdaiUABx3osbgLyInoejA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-get-function-arity": "^7.16.7",
+                "@babel/template": "^7.16.7",
+                "@babel/types": "^7.16.7"
+            }
+        },
+        "@babel/helper-get-function-arity": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.7.tgz",
+            "integrity": "sha512-flc+RLSOBXzNzVhcLu6ujeHUrD6tANAOU5ojrRx/as+tbzf8+stUCj7+IfRRoAbEZqj/ahXEMsjhOhgeZsrnTw==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.16.7"
+            }
+        },
+        "@babel/helper-hoist-variables": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.7.tgz",
+            "integrity": "sha512-m04d/0Op34H5v7pbZw6pSKP7weA6lsMvfiIAMeIvkY/R4xQtBSMFEigu9QTZ2qB/9l22vsxtM8a+Q8CzD255fg==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.16.7"
+            }
+        },
+        "@babel/helper-member-expression-to-functions": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.16.7.tgz",
+            "integrity": "sha512-VtJ/65tYiU/6AbMTDwyoXGPKHgTsfRarivm+YbB5uAzKUyuPjgZSgAFeG87FCigc7KNHu2Pegh1XIT3lXjvz3Q==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.16.7"
+            }
+        },
+        "@babel/helper-module-imports": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.16.7.tgz",
+            "integrity": "sha512-LVtS6TqjJHFc+nYeITRo6VLXve70xmq7wPhWTqDJusJEgGmkAACWwMiTNrvfoQo6hEhFwAIixNkvB0jPXDL8Wg==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.16.7"
+            }
+        },
+        "@babel/helper-module-transforms": {
+            "version": "7.17.6",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.17.6.tgz",
+            "integrity": "sha512-2ULmRdqoOMpdvkbT8jONrZML/XALfzxlb052bldftkicAUy8AxSCkD5trDPQcwHNmolcl7wP6ehNqMlyUw6AaA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-environment-visitor": "^7.16.7",
+                "@babel/helper-module-imports": "^7.16.7",
+                "@babel/helper-simple-access": "^7.16.7",
+                "@babel/helper-split-export-declaration": "^7.16.7",
+                "@babel/helper-validator-identifier": "^7.16.7",
+                "@babel/template": "^7.16.7",
+                "@babel/traverse": "^7.17.3",
+                "@babel/types": "^7.17.0"
+            }
+        },
+        "@babel/helper-optimise-call-expression": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.16.7.tgz",
+            "integrity": "sha512-EtgBhg7rd/JcnpZFXpBy0ze1YRfdm7BnBX4uKMBd3ixa3RGAE002JZB66FJyNH7g0F38U05pXmA5P8cBh7z+1w==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.16.7"
+            }
+        },
+        "@babel/helper-plugin-utils": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz",
+            "integrity": "sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA==",
+            "dev": true
+        },
+        "@babel/helper-regex": {
+            "version": "7.0.0-beta.53",
+            "resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.0.0-beta.53.tgz",
+            "integrity": "sha1-bp0hl7Vid54iVWWUaumoXCFbIl4=",
+            "dev": true,
+            "requires": {
+                "lodash": "^4.17.5"
+            }
+        },
+        "@babel/helper-remap-async-to-generator": {
+            "version": "7.16.8",
+            "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.16.8.tgz",
+            "integrity": "sha512-fm0gH7Flb8H51LqJHy3HJ3wnE1+qtYR2A99K06ahwrawLdOFsCEWjZOrYricXJHoPSudNKxrMBUPEIPxiIIvBw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-annotate-as-pure": "^7.16.7",
+                "@babel/helper-wrap-function": "^7.16.8",
+                "@babel/types": "^7.16.8"
+            }
+        },
+        "@babel/helper-replace-supers": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.16.7.tgz",
+            "integrity": "sha512-y9vsWilTNaVnVh6xiJfABzsNpgDPKev9HnAgz6Gb1p6UUwf9NepdlsV7VXGCftJM+jqD5f7JIEubcpLjZj5dBw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-environment-visitor": "^7.16.7",
+                "@babel/helper-member-expression-to-functions": "^7.16.7",
+                "@babel/helper-optimise-call-expression": "^7.16.7",
+                "@babel/traverse": "^7.16.7",
+                "@babel/types": "^7.16.7"
+            }
+        },
+        "@babel/helper-simple-access": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.16.7.tgz",
+            "integrity": "sha512-ZIzHVyoeLMvXMN/vok/a4LWRy8G2v205mNP0XOuf9XRLyX5/u9CnVulUtDgUTama3lT+bf/UqucuZjqiGuTS1g==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.16.7"
+            }
+        },
+        "@babel/helper-skip-transparent-expression-wrappers": {
+            "version": "7.16.0",
+            "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.16.0.tgz",
+            "integrity": "sha512-+il1gTy0oHwUsBQZyJvukbB4vPMdcYBrFHa0Uc4AizLxbq6BOYC51Rv4tWocX9BLBDLZ4kc6qUFpQ6HRgL+3zw==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.16.0"
+            }
+        },
+        "@babel/helper-split-export-declaration": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.7.tgz",
+            "integrity": "sha512-xbWoy/PFoxSWazIToT9Sif+jJTlrMcndIsaOKvTA6u7QEo7ilkRZpjew18/W3c7nm8fXdUDXh02VXTbZ0pGDNw==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.16.7"
+            }
+        },
+        "@babel/helper-validator-identifier": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
+            "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==",
+            "dev": true
+        },
+        "@babel/helper-validator-option": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.16.7.tgz",
+            "integrity": "sha512-TRtenOuRUVo9oIQGPC5G9DgK4743cdxvtOw0weQNpZXaS16SCBi5MNjZF8vba3ETURjZpTbVn7Vvcf2eAwFozQ==",
+            "dev": true
+        },
+        "@babel/helper-wrap-function": {
+            "version": "7.16.8",
+            "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.16.8.tgz",
+            "integrity": "sha512-8RpyRVIAW1RcDDGTA+GpPAwV22wXCfKOoM9bet6TLkGIFTkRQSkH1nMQ5Yet4MpoXe1ZwHPVtNasc2w0uZMqnw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-function-name": "^7.16.7",
+                "@babel/template": "^7.16.7",
+                "@babel/traverse": "^7.16.8",
+                "@babel/types": "^7.16.8"
+            }
+        },
+        "@babel/helpers": {
+            "version": "7.17.2",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.17.2.tgz",
+            "integrity": "sha512-0Qu7RLR1dILozr/6M0xgj+DFPmi6Bnulgm9M8BVa9ZCWxDqlSnqt3cf8IDPB5m45sVXUZ0kuQAgUrdSFFH79fQ==",
+            "dev": true,
+            "requires": {
+                "@babel/template": "^7.16.7",
+                "@babel/traverse": "^7.17.0",
+                "@babel/types": "^7.17.0"
+            }
+        },
+        "@babel/highlight": {
+            "version": "7.16.10",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.10.tgz",
+            "integrity": "sha512-5FnTQLSLswEj6IkgVw5KusNUUFY9ZGqe/TRFnP/BKYHYgfh7tc+C7mwiy95/yNP7Dh9x580Vv8r7u7ZfTBFxdw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-validator-identifier": "^7.16.7",
+                "chalk": "^2.0.0",
+                "js-tokens": "^4.0.0"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^1.9.0"
+                    }
+                },
+                "chalk": {
+                    "version": "2.4.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+                    "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "1.9.3",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+                    "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "1.1.3"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+                    "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+                    "dev": true
+                },
+                "has-flag": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+                    "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "5.5.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                }
+            }
+        },
+        "@babel/parser": {
+            "version": "7.17.3",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.3.tgz",
+            "integrity": "sha512-7yJPvPV+ESz2IUTPbOL+YkIGyCqOyNIzdguKQuJGnH7bg1WTIifuM21YqokFt/THWh1AkCRn9IgoykTRCBVpzA==",
+            "dev": true
+        },
+        "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.16.7.tgz",
+            "integrity": "sha512-anv/DObl7waiGEnC24O9zqL0pSuI9hljihqiDuFHC8d7/bjr/4RLGPWuc8rYOff/QPzbEPSkzG8wGG9aDuhHRg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.16.7"
+            }
+        },
+        "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.16.7.tgz",
+            "integrity": "sha512-di8vUHRdf+4aJ7ltXhaDbPoszdkh59AQtJM5soLsuHpQJdFQZOA4uGj0V2u/CZ8bJ/u8ULDL5yq6FO/bCXnKHw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.16.7",
+                "@babel/helper-skip-transparent-expression-wrappers": "^7.16.0",
+                "@babel/plugin-proposal-optional-chaining": "^7.16.7"
+            }
+        },
+        "@babel/plugin-proposal-async-generator-functions": {
+            "version": "7.16.8",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.16.8.tgz",
+            "integrity": "sha512-71YHIvMuiuqWJQkebWJtdhQTfd4Q4mF76q2IX37uZPkG9+olBxsX+rH1vkhFto4UeJZ9dPY2s+mDvhDm1u2BGQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.16.7",
+                "@babel/helper-remap-async-to-generator": "^7.16.8",
+                "@babel/plugin-syntax-async-generators": "^7.8.4"
+            }
+        },
+        "@babel/plugin-proposal-class-properties": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.16.7.tgz",
+            "integrity": "sha512-IobU0Xme31ewjYOShSIqd/ZGM/r/cuOz2z0MDbNrhF5FW+ZVgi0f2lyeoj9KFPDOAqsYxmLWZte1WOwlvY9aww==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-create-class-features-plugin": "^7.16.7",
+                "@babel/helper-plugin-utils": "^7.16.7"
+            }
+        },
+        "@babel/plugin-proposal-class-static-block": {
+            "version": "7.17.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-static-block/-/plugin-proposal-class-static-block-7.17.6.tgz",
+            "integrity": "sha512-X/tididvL2zbs7jZCeeRJ8167U/+Ac135AM6jCAx6gYXDUviZV5Ku9UDvWS2NCuWlFjIRXklYhwo6HhAC7ETnA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-create-class-features-plugin": "^7.17.6",
+                "@babel/helper-plugin-utils": "^7.16.7",
+                "@babel/plugin-syntax-class-static-block": "^7.14.5"
+            }
+        },
+        "@babel/plugin-proposal-dynamic-import": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.16.7.tgz",
+            "integrity": "sha512-I8SW9Ho3/8DRSdmDdH3gORdyUuYnk1m4cMxUAdu5oy4n3OfN8flDEH+d60iG7dUfi0KkYwSvoalHzzdRzpWHTg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.16.7",
+                "@babel/plugin-syntax-dynamic-import": "^7.8.3"
+            }
+        },
+        "@babel/plugin-proposal-export-namespace-from": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-export-namespace-from/-/plugin-proposal-export-namespace-from-7.16.7.tgz",
+            "integrity": "sha512-ZxdtqDXLRGBL64ocZcs7ovt71L3jhC1RGSyR996svrCi3PYqHNkb3SwPJCs8RIzD86s+WPpt2S73+EHCGO+NUA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.16.7",
+                "@babel/plugin-syntax-export-namespace-from": "^7.8.3"
+            }
+        },
+        "@babel/plugin-proposal-json-strings": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.16.7.tgz",
+            "integrity": "sha512-lNZ3EEggsGY78JavgbHsK9u5P3pQaW7k4axlgFLYkMd7UBsiNahCITShLjNQschPyjtO6dADrL24757IdhBrsQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.16.7",
+                "@babel/plugin-syntax-json-strings": "^7.8.3"
+            }
+        },
+        "@babel/plugin-proposal-logical-assignment-operators": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-logical-assignment-operators/-/plugin-proposal-logical-assignment-operators-7.16.7.tgz",
+            "integrity": "sha512-K3XzyZJGQCr00+EtYtrDjmwX7o7PLK6U9bi1nCwkQioRFVUv6dJoxbQjtWVtP+bCPy82bONBKG8NPyQ4+i6yjg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.16.7",
+                "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4"
+            }
+        },
+        "@babel/plugin-proposal-nullish-coalescing-operator": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.16.7.tgz",
+            "integrity": "sha512-aUOrYU3EVtjf62jQrCj63pYZ7k6vns2h/DQvHPWGmsJRYzWXZ6/AsfgpiRy6XiuIDADhJzP2Q9MwSMKauBQ+UQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.16.7",
+                "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3"
+            }
+        },
+        "@babel/plugin-proposal-numeric-separator": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.16.7.tgz",
+            "integrity": "sha512-vQgPMknOIgiuVqbokToyXbkY/OmmjAzr/0lhSIbG/KmnzXPGwW/AdhdKpi+O4X/VkWiWjnkKOBiqJrTaC98VKw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.16.7",
+                "@babel/plugin-syntax-numeric-separator": "^7.10.4"
+            }
+        },
+        "@babel/plugin-proposal-object-rest-spread": {
+            "version": "7.17.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.17.3.tgz",
+            "integrity": "sha512-yuL5iQA/TbZn+RGAfxQXfi7CNLmKi1f8zInn4IgobuCWcAb7i+zj4TYzQ9l8cEzVyJ89PDGuqxK1xZpUDISesw==",
+            "dev": true,
+            "requires": {
+                "@babel/compat-data": "^7.17.0",
+                "@babel/helper-compilation-targets": "^7.16.7",
+                "@babel/helper-plugin-utils": "^7.16.7",
+                "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+                "@babel/plugin-transform-parameters": "^7.16.7"
+            }
+        },
+        "@babel/plugin-proposal-optional-catch-binding": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.16.7.tgz",
+            "integrity": "sha512-eMOH/L4OvWSZAE1VkHbr1vckLG1WUcHGJSLqqQwl2GaUqG6QjddvrOaTUMNYiv77H5IKPMZ9U9P7EaHwvAShfA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.16.7",
+                "@babel/plugin-syntax-optional-catch-binding": "^7.8.3"
+            }
+        },
+        "@babel/plugin-proposal-optional-chaining": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.16.7.tgz",
+            "integrity": "sha512-eC3xy+ZrUcBtP7x+sq62Q/HYd674pPTb/77XZMb5wbDPGWIdUbSr4Agr052+zaUPSb+gGRnjxXfKFvx5iMJ+DA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.16.7",
+                "@babel/helper-skip-transparent-expression-wrappers": "^7.16.0",
+                "@babel/plugin-syntax-optional-chaining": "^7.8.3"
+            }
+        },
+        "@babel/plugin-proposal-private-methods": {
+            "version": "7.16.11",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-methods/-/plugin-proposal-private-methods-7.16.11.tgz",
+            "integrity": "sha512-F/2uAkPlXDr8+BHpZvo19w3hLFKge+k75XUprE6jaqKxjGkSYcK+4c+bup5PdW/7W/Rpjwql7FTVEDW+fRAQsw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-create-class-features-plugin": "^7.16.10",
+                "@babel/helper-plugin-utils": "^7.16.7"
+            }
+        },
+        "@babel/plugin-proposal-private-property-in-object": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.16.7.tgz",
+            "integrity": "sha512-rMQkjcOFbm+ufe3bTZLyOfsOUOxyvLXZJCTARhJr+8UMSoZmqTe1K1BgkFcrW37rAchWg57yI69ORxiWvUINuQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-annotate-as-pure": "^7.16.7",
+                "@babel/helper-create-class-features-plugin": "^7.16.7",
+                "@babel/helper-plugin-utils": "^7.16.7",
+                "@babel/plugin-syntax-private-property-in-object": "^7.14.5"
+            }
+        },
+        "@babel/plugin-proposal-unicode-property-regex": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.16.7.tgz",
+            "integrity": "sha512-QRK0YI/40VLhNVGIjRNAAQkEHws0cswSdFFjpFyt943YmJIU1da9uW63Iu6NFV6CxTZW5eTDCrwZUstBWgp/Rg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-create-regexp-features-plugin": "^7.16.7",
+                "@babel/helper-plugin-utils": "^7.16.7"
+            }
+        },
+        "@babel/plugin-syntax-async-generators": {
+            "version": "7.8.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
+            "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.8.0"
+            }
+        },
+        "@babel/plugin-syntax-class-properties": {
+            "version": "7.12.13",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
+            "integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.12.13"
+            }
+        },
+        "@babel/plugin-syntax-class-static-block": {
+            "version": "7.14.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz",
+            "integrity": "sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.14.5"
+            }
+        },
+        "@babel/plugin-syntax-dynamic-import": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.8.3.tgz",
+            "integrity": "sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.8.0"
+            }
+        },
+        "@babel/plugin-syntax-export-namespace-from": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-export-namespace-from/-/plugin-syntax-export-namespace-from-7.8.3.tgz",
+            "integrity": "sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.8.3"
+            }
+        },
+        "@babel/plugin-syntax-json-strings": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
+            "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.8.0"
+            }
+        },
+        "@babel/plugin-syntax-logical-assignment-operators": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
+            "integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4"
+            }
+        },
+        "@babel/plugin-syntax-nullish-coalescing-operator": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
+            "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.8.0"
+            }
+        },
+        "@babel/plugin-syntax-numeric-separator": {
+            "version": "7.10.4",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
+            "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4"
+            }
+        },
+        "@babel/plugin-syntax-object-rest-spread": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
+            "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.8.0"
+            }
+        },
+        "@babel/plugin-syntax-optional-catch-binding": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
+            "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.8.0"
+            }
+        },
+        "@babel/plugin-syntax-optional-chaining": {
+            "version": "7.8.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
+            "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.8.0"
+            }
+        },
+        "@babel/plugin-syntax-private-property-in-object": {
+            "version": "7.14.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
+            "integrity": "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.14.5"
+            }
+        },
+        "@babel/plugin-syntax-top-level-await": {
+            "version": "7.14.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
+            "integrity": "sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.14.5"
+            }
+        },
+        "@babel/plugin-transform-arrow-functions": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.16.7.tgz",
+            "integrity": "sha512-9ffkFFMbvzTvv+7dTp/66xvZAWASuPD5Tl9LK3Z9vhOmANo6j94rik+5YMBt4CwHVMWLWpMsriIc2zsa3WW3xQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.16.7"
+            }
+        },
+        "@babel/plugin-transform-async-to-generator": {
+            "version": "7.16.8",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.16.8.tgz",
+            "integrity": "sha512-MtmUmTJQHCnyJVrScNzNlofQJ3dLFuobYn3mwOTKHnSCMtbNsqvF71GQmJfFjdrXSsAA7iysFmYWw4bXZ20hOg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-module-imports": "^7.16.7",
+                "@babel/helper-plugin-utils": "^7.16.7",
+                "@babel/helper-remap-async-to-generator": "^7.16.8"
+            }
+        },
+        "@babel/plugin-transform-block-scoped-functions": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.16.7.tgz",
+            "integrity": "sha512-JUuzlzmF40Z9cXyytcbZEZKckgrQzChbQJw/5PuEHYeqzCsvebDx0K0jWnIIVcmmDOAVctCgnYs0pMcrYj2zJg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.16.7"
+            }
+        },
+        "@babel/plugin-transform-block-scoping": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.16.7.tgz",
+            "integrity": "sha512-ObZev2nxVAYA4bhyusELdo9hb3H+A56bxH3FZMbEImZFiEDYVHXQSJ1hQKFlDnlt8G9bBrCZ5ZpURZUrV4G5qQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.16.7"
+            }
+        },
+        "@babel/plugin-transform-classes": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.16.7.tgz",
+            "integrity": "sha512-WY7og38SFAGYRe64BrjKf8OrE6ulEHtr5jEYaZMwox9KebgqPi67Zqz8K53EKk1fFEJgm96r32rkKZ3qA2nCWQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-annotate-as-pure": "^7.16.7",
+                "@babel/helper-environment-visitor": "^7.16.7",
+                "@babel/helper-function-name": "^7.16.7",
+                "@babel/helper-optimise-call-expression": "^7.16.7",
+                "@babel/helper-plugin-utils": "^7.16.7",
+                "@babel/helper-replace-supers": "^7.16.7",
+                "@babel/helper-split-export-declaration": "^7.16.7",
+                "globals": "^11.1.0"
+            }
+        },
+        "@babel/plugin-transform-computed-properties": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.16.7.tgz",
+            "integrity": "sha512-gN72G9bcmenVILj//sv1zLNaPyYcOzUho2lIJBMh/iakJ9ygCo/hEF9cpGb61SCMEDxbbyBoVQxrt+bWKu5KGw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.16.7"
+            }
+        },
+        "@babel/plugin-transform-destructuring": {
+            "version": "7.17.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.17.3.tgz",
+            "integrity": "sha512-dDFzegDYKlPqa72xIlbmSkly5MluLoaC1JswABGktyt6NTXSBcUuse/kWE/wvKFWJHPETpi158qJZFS3JmykJg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.16.7"
+            }
+        },
+        "@babel/plugin-transform-dotall-regex": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.16.7.tgz",
+            "integrity": "sha512-Lyttaao2SjZF6Pf4vk1dVKv8YypMpomAbygW+mU5cYP3S5cWTfCJjG8xV6CFdzGFlfWK81IjL9viiTvpb6G7gQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-create-regexp-features-plugin": "^7.16.7",
+                "@babel/helper-plugin-utils": "^7.16.7"
+            }
+        },
+        "@babel/plugin-transform-duplicate-keys": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.16.7.tgz",
+            "integrity": "sha512-03DvpbRfvWIXyK0/6QiR1KMTWeT6OcQ7tbhjrXyFS02kjuX/mu5Bvnh5SDSWHxyawit2g5aWhKwI86EE7GUnTw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.16.7"
+            }
+        },
+        "@babel/plugin-transform-exponentiation-operator": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.16.7.tgz",
+            "integrity": "sha512-8UYLSlyLgRixQvlYH3J2ekXFHDFLQutdy7FfFAMm3CPZ6q9wHCwnUyiXpQCe3gVVnQlHc5nsuiEVziteRNTXEA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-builder-binary-assignment-operator-visitor": "^7.16.7",
+                "@babel/helper-plugin-utils": "^7.16.7"
+            }
+        },
+        "@babel/plugin-transform-for-of": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.16.7.tgz",
+            "integrity": "sha512-/QZm9W92Ptpw7sjI9Nx1mbcsWz33+l8kuMIQnDwgQBG5s3fAfQvkRjQ7NqXhtNcKOnPkdICmUHyCaWW06HCsqg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.16.7"
+            }
+        },
+        "@babel/plugin-transform-function-name": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.16.7.tgz",
+            "integrity": "sha512-SU/C68YVwTRxqWj5kgsbKINakGag0KTgq9f2iZEXdStoAbOzLHEBRYzImmA6yFo8YZhJVflvXmIHUO7GWHmxxA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-compilation-targets": "^7.16.7",
+                "@babel/helper-function-name": "^7.16.7",
+                "@babel/helper-plugin-utils": "^7.16.7"
+            }
+        },
+        "@babel/plugin-transform-instanceof": {
+            "version": "7.0.0-beta.53",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-instanceof/-/plugin-transform-instanceof-7.0.0-beta.53.tgz",
+            "integrity": "sha1-WC2CtyUYggGtDiIx8fzpTHRaLAY=",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "7.0.0-beta.53"
+            },
+            "dependencies": {
+                "@babel/helper-plugin-utils": {
+                    "version": "7.0.0-beta.53",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.53.tgz",
+                    "integrity": "sha1-1kRYY2/8JYtCcUqd2Trrb4uM8+0=",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/plugin-transform-literals": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.16.7.tgz",
+            "integrity": "sha512-6tH8RTpTWI0s2sV6uq3e/C9wPo4PTqqZps4uF0kzQ9/xPLFQtipynvmT1g/dOfEJ+0EQsHhkQ/zyRId8J2b8zQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.16.7"
+            }
+        },
+        "@babel/plugin-transform-member-expression-literals": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.16.7.tgz",
+            "integrity": "sha512-mBruRMbktKQwbxaJof32LT9KLy2f3gH+27a5XSuXo6h7R3vqltl0PgZ80C8ZMKw98Bf8bqt6BEVi3svOh2PzMw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.16.7"
+            }
+        },
+        "@babel/plugin-transform-modules-amd": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.16.7.tgz",
+            "integrity": "sha512-KaaEtgBL7FKYwjJ/teH63oAmE3lP34N3kshz8mm4VMAw7U3PxjVwwUmxEFksbgsNUaO3wId9R2AVQYSEGRa2+g==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-module-transforms": "^7.16.7",
+                "@babel/helper-plugin-utils": "^7.16.7",
+                "babel-plugin-dynamic-import-node": "^2.3.3"
+            }
+        },
+        "@babel/plugin-transform-modules-commonjs": {
+            "version": "7.16.8",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.16.8.tgz",
+            "integrity": "sha512-oflKPvsLT2+uKQopesJt3ApiaIS2HW+hzHFcwRNtyDGieAeC/dIHZX8buJQ2J2X1rxGPy4eRcUijm3qcSPjYcA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-module-transforms": "^7.16.7",
+                "@babel/helper-plugin-utils": "^7.16.7",
+                "@babel/helper-simple-access": "^7.16.7",
+                "babel-plugin-dynamic-import-node": "^2.3.3"
+            }
+        },
+        "@babel/plugin-transform-modules-systemjs": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.16.7.tgz",
+            "integrity": "sha512-DuK5E3k+QQmnOqBR9UkusByy5WZWGRxfzV529s9nPra1GE7olmxfqO2FHobEOYSPIjPBTr4p66YDcjQnt8cBmw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-hoist-variables": "^7.16.7",
+                "@babel/helper-module-transforms": "^7.16.7",
+                "@babel/helper-plugin-utils": "^7.16.7",
+                "@babel/helper-validator-identifier": "^7.16.7",
+                "babel-plugin-dynamic-import-node": "^2.3.3"
+            }
+        },
+        "@babel/plugin-transform-modules-umd": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.16.7.tgz",
+            "integrity": "sha512-EMh7uolsC8O4xhudF2F6wedbSHm1HHZ0C6aJ7K67zcDNidMzVcxWdGr+htW9n21klm+bOn+Rx4CBsAntZd3rEQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-module-transforms": "^7.16.7",
+                "@babel/helper-plugin-utils": "^7.16.7"
+            }
+        },
+        "@babel/plugin-transform-named-capturing-groups-regex": {
+            "version": "7.16.8",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.16.8.tgz",
+            "integrity": "sha512-j3Jw+n5PvpmhRR+mrgIh04puSANCk/T/UA3m3P1MjJkhlK906+ApHhDIqBQDdOgL/r1UYpz4GNclTXxyZrYGSw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-create-regexp-features-plugin": "^7.16.7"
+            }
+        },
+        "@babel/plugin-transform-new-target": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.16.7.tgz",
+            "integrity": "sha512-xiLDzWNMfKoGOpc6t3U+etCE2yRnn3SM09BXqWPIZOBpL2gvVrBWUKnsJx0K/ADi5F5YC5f8APFfWrz25TdlGg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.16.7"
+            }
+        },
+        "@babel/plugin-transform-object-super": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.16.7.tgz",
+            "integrity": "sha512-14J1feiQVWaGvRxj2WjyMuXS2jsBkgB3MdSN5HuC2G5nRspa5RK9COcs82Pwy5BuGcjb+fYaUj94mYcOj7rCvw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.16.7",
+                "@babel/helper-replace-supers": "^7.16.7"
+            }
+        },
+        "@babel/plugin-transform-parameters": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.16.7.tgz",
+            "integrity": "sha512-AT3MufQ7zZEhU2hwOA11axBnExW0Lszu4RL/tAlUJBuNoRak+wehQW8h6KcXOcgjY42fHtDxswuMhMjFEuv/aw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.16.7"
+            }
+        },
+        "@babel/plugin-transform-property-literals": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.16.7.tgz",
+            "integrity": "sha512-z4FGr9NMGdoIl1RqavCqGG+ZuYjfZ/hkCIeuH6Do7tXmSm0ls11nYVSJqFEUOSJbDab5wC6lRE/w6YjVcr6Hqw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.16.7"
+            }
+        },
+        "@babel/plugin-transform-regenerator": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.16.7.tgz",
+            "integrity": "sha512-mF7jOgGYCkSJagJ6XCujSQg+6xC1M77/03K2oBmVJWoFGNUtnVJO4WHKJk3dnPC8HCcj4xBQP1Egm8DWh3Pb3Q==",
+            "dev": true,
+            "requires": {
+                "regenerator-transform": "^0.14.2"
+            }
+        },
+        "@babel/plugin-transform-reserved-words": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.16.7.tgz",
+            "integrity": "sha512-KQzzDnZ9hWQBjwi5lpY5v9shmm6IVG0U9pB18zvMu2i4H90xpT4gmqwPYsn8rObiadYe2M0gmgsiOIF5A/2rtg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.16.7"
+            }
+        },
+        "@babel/plugin-transform-shorthand-properties": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.16.7.tgz",
+            "integrity": "sha512-hah2+FEnoRoATdIb05IOXf+4GzXYTq75TVhIn1PewihbpyrNWUt2JbudKQOETWw6QpLe+AIUpJ5MVLYTQbeeUg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.16.7"
+            }
+        },
+        "@babel/plugin-transform-spread": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.16.7.tgz",
+            "integrity": "sha512-+pjJpgAngb53L0iaA5gU/1MLXJIfXcYepLgXB3esVRf4fqmj8f2cxM3/FKaHsZms08hFQJkFccEWuIpm429TXg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.16.7",
+                "@babel/helper-skip-transparent-expression-wrappers": "^7.16.0"
+            }
+        },
+        "@babel/plugin-transform-sticky-regex": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.16.7.tgz",
+            "integrity": "sha512-NJa0Bd/87QV5NZZzTuZG5BPJjLYadeSZ9fO6oOUoL4iQx+9EEuw/eEM92SrsT19Yc2jgB1u1hsjqDtH02c3Drw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.16.7"
+            }
+        },
+        "@babel/plugin-transform-template-literals": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.16.7.tgz",
+            "integrity": "sha512-VwbkDDUeenlIjmfNeDX/V0aWrQH2QiVyJtwymVQSzItFDTpxfyJh3EVaQiS0rIN/CqbLGr0VcGmuwyTdZtdIsA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.16.7"
+            }
+        },
+        "@babel/plugin-transform-typeof-symbol": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.16.7.tgz",
+            "integrity": "sha512-p2rOixCKRJzpg9JB4gjnG4gjWkWa89ZoYUnl9snJ1cWIcTH/hvxZqfO+WjG6T8DRBpctEol5jw1O5rA8gkCokQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.16.7"
+            }
+        },
+        "@babel/plugin-transform-unicode-escapes": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.16.7.tgz",
+            "integrity": "sha512-TAV5IGahIz3yZ9/Hfv35TV2xEm+kaBDaZQCn2S/hG9/CZ0DktxJv9eKfPc7yYCvOYR4JGx1h8C+jcSOvgaaI/Q==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.16.7"
+            }
+        },
+        "@babel/plugin-transform-unicode-regex": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.16.7.tgz",
+            "integrity": "sha512-oC5tYYKw56HO75KZVLQ+R/Nl3Hro9kf8iG0hXoaHP7tjAyCpvqBiSNe6vGrZni1Z6MggmUOC6A7VP7AVmw225Q==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-create-regexp-features-plugin": "^7.16.7",
+                "@babel/helper-plugin-utils": "^7.16.7"
+            }
+        },
+        "@babel/preset-env": {
+            "version": "7.16.11",
+            "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.16.11.tgz",
+            "integrity": "sha512-qcmWG8R7ZW6WBRPZK//y+E3Cli151B20W1Rv7ln27vuPaXU/8TKms6jFdiJtF7UDTxcrb7mZd88tAeK9LjdT8g==",
+            "dev": true,
+            "requires": {
+                "@babel/compat-data": "^7.16.8",
+                "@babel/helper-compilation-targets": "^7.16.7",
+                "@babel/helper-plugin-utils": "^7.16.7",
+                "@babel/helper-validator-option": "^7.16.7",
+                "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.16.7",
+                "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.16.7",
+                "@babel/plugin-proposal-async-generator-functions": "^7.16.8",
+                "@babel/plugin-proposal-class-properties": "^7.16.7",
+                "@babel/plugin-proposal-class-static-block": "^7.16.7",
+                "@babel/plugin-proposal-dynamic-import": "^7.16.7",
+                "@babel/plugin-proposal-export-namespace-from": "^7.16.7",
+                "@babel/plugin-proposal-json-strings": "^7.16.7",
+                "@babel/plugin-proposal-logical-assignment-operators": "^7.16.7",
+                "@babel/plugin-proposal-nullish-coalescing-operator": "^7.16.7",
+                "@babel/plugin-proposal-numeric-separator": "^7.16.7",
+                "@babel/plugin-proposal-object-rest-spread": "^7.16.7",
+                "@babel/plugin-proposal-optional-catch-binding": "^7.16.7",
+                "@babel/plugin-proposal-optional-chaining": "^7.16.7",
+                "@babel/plugin-proposal-private-methods": "^7.16.11",
+                "@babel/plugin-proposal-private-property-in-object": "^7.16.7",
+                "@babel/plugin-proposal-unicode-property-regex": "^7.16.7",
+                "@babel/plugin-syntax-async-generators": "^7.8.4",
+                "@babel/plugin-syntax-class-properties": "^7.12.13",
+                "@babel/plugin-syntax-class-static-block": "^7.14.5",
+                "@babel/plugin-syntax-dynamic-import": "^7.8.3",
+                "@babel/plugin-syntax-export-namespace-from": "^7.8.3",
+                "@babel/plugin-syntax-json-strings": "^7.8.3",
+                "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
+                "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+                "@babel/plugin-syntax-numeric-separator": "^7.10.4",
+                "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+                "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+                "@babel/plugin-syntax-optional-chaining": "^7.8.3",
+                "@babel/plugin-syntax-private-property-in-object": "^7.14.5",
+                "@babel/plugin-syntax-top-level-await": "^7.14.5",
+                "@babel/plugin-transform-arrow-functions": "^7.16.7",
+                "@babel/plugin-transform-async-to-generator": "^7.16.8",
+                "@babel/plugin-transform-block-scoped-functions": "^7.16.7",
+                "@babel/plugin-transform-block-scoping": "^7.16.7",
+                "@babel/plugin-transform-classes": "^7.16.7",
+                "@babel/plugin-transform-computed-properties": "^7.16.7",
+                "@babel/plugin-transform-destructuring": "^7.16.7",
+                "@babel/plugin-transform-dotall-regex": "^7.16.7",
+                "@babel/plugin-transform-duplicate-keys": "^7.16.7",
+                "@babel/plugin-transform-exponentiation-operator": "^7.16.7",
+                "@babel/plugin-transform-for-of": "^7.16.7",
+                "@babel/plugin-transform-function-name": "^7.16.7",
+                "@babel/plugin-transform-literals": "^7.16.7",
+                "@babel/plugin-transform-member-expression-literals": "^7.16.7",
+                "@babel/plugin-transform-modules-amd": "^7.16.7",
+                "@babel/plugin-transform-modules-commonjs": "^7.16.8",
+                "@babel/plugin-transform-modules-systemjs": "^7.16.7",
+                "@babel/plugin-transform-modules-umd": "^7.16.7",
+                "@babel/plugin-transform-named-capturing-groups-regex": "^7.16.8",
+                "@babel/plugin-transform-new-target": "^7.16.7",
+                "@babel/plugin-transform-object-super": "^7.16.7",
+                "@babel/plugin-transform-parameters": "^7.16.7",
+                "@babel/plugin-transform-property-literals": "^7.16.7",
+                "@babel/plugin-transform-regenerator": "^7.16.7",
+                "@babel/plugin-transform-reserved-words": "^7.16.7",
+                "@babel/plugin-transform-shorthand-properties": "^7.16.7",
+                "@babel/plugin-transform-spread": "^7.16.7",
+                "@babel/plugin-transform-sticky-regex": "^7.16.7",
+                "@babel/plugin-transform-template-literals": "^7.16.7",
+                "@babel/plugin-transform-typeof-symbol": "^7.16.7",
+                "@babel/plugin-transform-unicode-escapes": "^7.16.7",
+                "@babel/plugin-transform-unicode-regex": "^7.16.7",
+                "@babel/preset-modules": "^0.1.5",
+                "@babel/types": "^7.16.8",
+                "babel-plugin-polyfill-corejs2": "^0.3.0",
+                "babel-plugin-polyfill-corejs3": "^0.5.0",
+                "babel-plugin-polyfill-regenerator": "^0.3.0",
+                "core-js-compat": "^3.20.2",
+                "semver": "^6.3.0"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/preset-es2015": {
+            "version": "7.0.0-beta.53",
+            "resolved": "https://registry.npmjs.org/@babel/preset-es2015/-/preset-es2015-7.0.0-beta.53.tgz",
+            "integrity": "sha1-SYL6GUjbEJN2Yoj2mRPizjYDEeQ=",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "7.0.0-beta.53",
+                "@babel/plugin-transform-arrow-functions": "7.0.0-beta.53",
+                "@babel/plugin-transform-block-scoped-functions": "7.0.0-beta.53",
+                "@babel/plugin-transform-block-scoping": "7.0.0-beta.53",
+                "@babel/plugin-transform-classes": "7.0.0-beta.53",
+                "@babel/plugin-transform-computed-properties": "7.0.0-beta.53",
+                "@babel/plugin-transform-destructuring": "7.0.0-beta.53",
+                "@babel/plugin-transform-duplicate-keys": "7.0.0-beta.53",
+                "@babel/plugin-transform-for-of": "7.0.0-beta.53",
+                "@babel/plugin-transform-function-name": "7.0.0-beta.53",
+                "@babel/plugin-transform-instanceof": "7.0.0-beta.53",
+                "@babel/plugin-transform-literals": "7.0.0-beta.53",
+                "@babel/plugin-transform-modules-amd": "7.0.0-beta.53",
+                "@babel/plugin-transform-modules-commonjs": "7.0.0-beta.53",
+                "@babel/plugin-transform-modules-systemjs": "7.0.0-beta.53",
+                "@babel/plugin-transform-modules-umd": "7.0.0-beta.53",
+                "@babel/plugin-transform-object-super": "7.0.0-beta.53",
+                "@babel/plugin-transform-parameters": "7.0.0-beta.53",
+                "@babel/plugin-transform-regenerator": "7.0.0-beta.53",
+                "@babel/plugin-transform-shorthand-properties": "7.0.0-beta.53",
+                "@babel/plugin-transform-spread": "7.0.0-beta.53",
+                "@babel/plugin-transform-sticky-regex": "7.0.0-beta.53",
+                "@babel/plugin-transform-template-literals": "7.0.0-beta.53",
+                "@babel/plugin-transform-typeof-symbol": "7.0.0-beta.53",
+                "@babel/plugin-transform-unicode-regex": "7.0.0-beta.53"
+            },
+            "dependencies": {
+                "@babel/code-frame": {
+                    "version": "7.0.0-beta.53",
+                    "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.53.tgz",
+                    "integrity": "sha1-mA0VYLhjV1v1o3eSUDfgEy71kh4=",
+                    "dev": true,
+                    "requires": {
+                        "@babel/highlight": "7.0.0-beta.53"
+                    }
+                },
+                "@babel/generator": {
+                    "version": "7.0.0-beta.53",
+                    "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.53.tgz",
+                    "integrity": "sha1-uMrXLFcr4yNK/94ivm2sxCUOA0s=",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "7.0.0-beta.53",
+                        "jsesc": "^2.5.1",
+                        "lodash": "^4.17.5",
+                        "source-map": "^0.5.0",
+                        "trim-right": "^1.0.1"
+                    }
+                },
+                "@babel/helper-annotate-as-pure": {
+                    "version": "7.0.0-beta.53",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.0.0-beta.53.tgz",
+                    "integrity": "sha1-WZYGKDdcvu+WoH7f4co4t1bwGqg=",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "7.0.0-beta.53"
+                    }
+                },
+                "@babel/helper-function-name": {
+                    "version": "7.0.0-beta.53",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.53.tgz",
+                    "integrity": "sha1-USgEro6cvOVDHr6hnkdijC7WU/I=",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-get-function-arity": "7.0.0-beta.53",
+                        "@babel/template": "7.0.0-beta.53",
+                        "@babel/types": "7.0.0-beta.53"
+                    }
+                },
+                "@babel/helper-get-function-arity": {
+                    "version": "7.0.0-beta.53",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.53.tgz",
+                    "integrity": "sha1-3tiKsp+bHbYch9G7jTijXdp3neY=",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "7.0.0-beta.53"
+                    }
+                },
+                "@babel/helper-hoist-variables": {
+                    "version": "7.0.0-beta.53",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.0.0-beta.53.tgz",
+                    "integrity": "sha1-TCfjuHP6CcWtbpPrQHBMIA+EE3w=",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "7.0.0-beta.53"
+                    }
+                },
+                "@babel/helper-member-expression-to-functions": {
+                    "version": "7.0.0-beta.53",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.0.0-beta.53.tgz",
+                    "integrity": "sha1-D7Dviy07kD0cO/Qm2kp0V14BnOQ=",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "7.0.0-beta.53"
+                    }
+                },
+                "@babel/helper-module-imports": {
+                    "version": "7.0.0-beta.53",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0-beta.53.tgz",
+                    "integrity": "sha1-5zXmqjClBLD52Fw4ptRwqfSqgdk=",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "7.0.0-beta.53",
+                        "lodash": "^4.17.5"
+                    }
+                },
+                "@babel/helper-module-transforms": {
+                    "version": "7.0.0-beta.53",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.0.0-beta.53.tgz",
+                    "integrity": "sha1-e6IUzcyPhiPy0Xl96v8f80mqzhM=",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-module-imports": "7.0.0-beta.53",
+                        "@babel/helper-simple-access": "7.0.0-beta.53",
+                        "@babel/helper-split-export-declaration": "7.0.0-beta.53",
+                        "@babel/template": "7.0.0-beta.53",
+                        "@babel/types": "7.0.0-beta.53",
+                        "lodash": "^4.17.5"
+                    }
+                },
+                "@babel/helper-optimise-call-expression": {
+                    "version": "7.0.0-beta.53",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0-beta.53.tgz",
+                    "integrity": "sha1-j8eO9MD2n4uzu980zSMsIBIEFMg=",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "7.0.0-beta.53"
+                    }
+                },
+                "@babel/helper-plugin-utils": {
+                    "version": "7.0.0-beta.53",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.53.tgz",
+                    "integrity": "sha1-1kRYY2/8JYtCcUqd2Trrb4uM8+0=",
+                    "dev": true
+                },
+                "@babel/helper-replace-supers": {
+                    "version": "7.0.0-beta.53",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.0.0-beta.53.tgz",
+                    "integrity": "sha1-M5tb3BAilElbGifFWBMjBuG3vKc=",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-member-expression-to-functions": "7.0.0-beta.53",
+                        "@babel/helper-optimise-call-expression": "7.0.0-beta.53",
+                        "@babel/traverse": "7.0.0-beta.53",
+                        "@babel/types": "7.0.0-beta.53"
+                    }
+                },
+                "@babel/helper-simple-access": {
+                    "version": "7.0.0-beta.53",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.0.0-beta.53.tgz",
+                    "integrity": "sha1-cvbbmr5C+GgfpvAo79WdgVRHUrM=",
+                    "dev": true,
+                    "requires": {
+                        "@babel/template": "7.0.0-beta.53",
+                        "@babel/types": "7.0.0-beta.53",
+                        "lodash": "^4.17.5"
+                    }
+                },
+                "@babel/helper-split-export-declaration": {
+                    "version": "7.0.0-beta.53",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.53.tgz",
+                    "integrity": "sha1-rvVLix+ZYW6jfJhHhxajeAJjMls=",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "7.0.0-beta.53"
+                    }
+                },
+                "@babel/highlight": {
+                    "version": "7.0.0-beta.53",
+                    "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.53.tgz",
+                    "integrity": "sha1-9OlS2tF4fSBeGI0+OEzc5JyjaPs=",
+                    "dev": true,
+                    "requires": {
+                        "chalk": "^2.0.0",
+                        "esutils": "^2.0.2",
+                        "js-tokens": "^3.0.0"
+                    }
+                },
+                "@babel/parser": {
+                    "version": "7.0.0-beta.53",
+                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-beta.53.tgz",
+                    "integrity": "sha1-H0XrYXv5Rj1IKywE00nZ5O2/SJI=",
+                    "dev": true
+                },
+                "@babel/plugin-transform-arrow-functions": {
+                    "version": "7.0.0-beta.53",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.0.0-beta.53.tgz",
+                    "integrity": "sha1-p19fqEl6rBcp0DO/QcJQQWudHgQ=",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "7.0.0-beta.53"
+                    }
+                },
+                "@babel/plugin-transform-block-scoped-functions": {
+                    "version": "7.0.0-beta.53",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.0.0-beta.53.tgz",
+                    "integrity": "sha1-CkMiGhsMkM1NCfG0a5Wd0khlf3M=",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "7.0.0-beta.53"
+                    }
+                },
+                "@babel/plugin-transform-block-scoping": {
+                    "version": "7.0.0-beta.53",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.0.0-beta.53.tgz",
+                    "integrity": "sha1-nv1uUMofo5jcqnEZYh2j8fu4IbY=",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "7.0.0-beta.53",
+                        "lodash": "^4.17.5"
+                    }
+                },
+                "@babel/plugin-transform-classes": {
+                    "version": "7.0.0-beta.53",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.0.0-beta.53.tgz",
+                    "integrity": "sha1-XcLsMb8emAZqzfDEiHt3RMFL7G4=",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-annotate-as-pure": "7.0.0-beta.53",
+                        "@babel/helper-define-map": "7.0.0-beta.53",
+                        "@babel/helper-function-name": "7.0.0-beta.53",
+                        "@babel/helper-optimise-call-expression": "7.0.0-beta.53",
+                        "@babel/helper-plugin-utils": "7.0.0-beta.53",
+                        "@babel/helper-replace-supers": "7.0.0-beta.53",
+                        "@babel/helper-split-export-declaration": "7.0.0-beta.53",
+                        "globals": "^11.1.0"
+                    }
+                },
+                "@babel/plugin-transform-computed-properties": {
+                    "version": "7.0.0-beta.53",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.0.0-beta.53.tgz",
+                    "integrity": "sha1-l0fiYIKulO2lMPmNLCBZ6NLbwAU=",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "7.0.0-beta.53"
+                    }
+                },
+                "@babel/plugin-transform-destructuring": {
+                    "version": "7.0.0-beta.53",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.0.0-beta.53.tgz",
+                    "integrity": "sha1-DwrbDhptzTWjZkEBYJ7AYv8SenY=",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "7.0.0-beta.53"
+                    }
+                },
+                "@babel/plugin-transform-duplicate-keys": {
+                    "version": "7.0.0-beta.53",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.0.0-beta.53.tgz",
+                    "integrity": "sha1-D1WZE6v6GCOcpOCPc+7DbF5XuB8=",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "7.0.0-beta.53"
+                    }
+                },
+                "@babel/plugin-transform-for-of": {
+                    "version": "7.0.0-beta.53",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.0.0-beta.53.tgz",
+                    "integrity": "sha1-+gZSFeGFacj3TdUktXIeEdzKlzs=",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "7.0.0-beta.53"
+                    }
+                },
+                "@babel/plugin-transform-function-name": {
+                    "version": "7.0.0-beta.53",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.0.0-beta.53.tgz",
+                    "integrity": "sha1-Kzpbs2TB4cV+zL/iXGv1XygEET4=",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-function-name": "7.0.0-beta.53",
+                        "@babel/helper-plugin-utils": "7.0.0-beta.53"
+                    }
+                },
+                "@babel/plugin-transform-literals": {
+                    "version": "7.0.0-beta.53",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.0.0-beta.53.tgz",
+                    "integrity": "sha1-vsTxROmpbvUSHRQwx+vl/QiGV8k=",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "7.0.0-beta.53"
+                    }
+                },
+                "@babel/plugin-transform-modules-amd": {
+                    "version": "7.0.0-beta.53",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.0.0-beta.53.tgz",
+                    "integrity": "sha1-WFTXOeZ5IzqId8C0GCaca+t6Miw=",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-module-transforms": "7.0.0-beta.53",
+                        "@babel/helper-plugin-utils": "7.0.0-beta.53"
+                    }
+                },
+                "@babel/plugin-transform-modules-commonjs": {
+                    "version": "7.0.0-beta.53",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.0.0-beta.53.tgz",
+                    "integrity": "sha1-68P7ocWmyHQ7kJQD7NPn42gcr6U=",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-module-transforms": "7.0.0-beta.53",
+                        "@babel/helper-plugin-utils": "7.0.0-beta.53",
+                        "@babel/helper-simple-access": "7.0.0-beta.53"
+                    }
+                },
+                "@babel/plugin-transform-modules-systemjs": {
+                    "version": "7.0.0-beta.53",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.0.0-beta.53.tgz",
+                    "integrity": "sha1-uA/NnBWXLcaCMhT1JIUnhgu/BY4=",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-hoist-variables": "7.0.0-beta.53",
+                        "@babel/helper-plugin-utils": "7.0.0-beta.53"
+                    }
+                },
+                "@babel/plugin-transform-modules-umd": {
+                    "version": "7.0.0-beta.53",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.0.0-beta.53.tgz",
+                    "integrity": "sha1-Kjar5AodpnbkOhwwcVeOJ70tZ50=",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-module-transforms": "7.0.0-beta.53",
+                        "@babel/helper-plugin-utils": "7.0.0-beta.53"
+                    }
+                },
+                "@babel/plugin-transform-object-super": {
+                    "version": "7.0.0-beta.53",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.0.0-beta.53.tgz",
+                    "integrity": "sha1-4sTwbts0s9eksnV7oYgp0N8gKcs=",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "7.0.0-beta.53",
+                        "@babel/helper-replace-supers": "7.0.0-beta.53"
+                    }
+                },
+                "@babel/plugin-transform-parameters": {
+                    "version": "7.0.0-beta.53",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.0.0-beta.53.tgz",
+                    "integrity": "sha1-7+YM7IzsoNGdXG+hrnm8TjMnnVY=",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-call-delegate": "7.0.0-beta.53",
+                        "@babel/helper-get-function-arity": "7.0.0-beta.53",
+                        "@babel/helper-plugin-utils": "7.0.0-beta.53"
+                    }
+                },
+                "@babel/plugin-transform-regenerator": {
+                    "version": "7.0.0-beta.53",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.0.0-beta.53.tgz",
+                    "integrity": "sha1-T+u/YISvoMHJ7ISX3mjAaV/p2gs=",
+                    "dev": true,
+                    "requires": {
+                        "regenerator-transform": "^0.13.3"
+                    }
+                },
+                "@babel/plugin-transform-shorthand-properties": {
+                    "version": "7.0.0-beta.53",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.0.0-beta.53.tgz",
+                    "integrity": "sha1-38SIG2vXZYoAMew7gWPliPCJjUs=",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "7.0.0-beta.53"
+                    }
+                },
+                "@babel/plugin-transform-spread": {
+                    "version": "7.0.0-beta.53",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.0.0-beta.53.tgz",
+                    "integrity": "sha1-g+j2Rsok8cmCKPnxREz2DL1JOLw=",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "7.0.0-beta.53"
+                    }
+                },
+                "@babel/plugin-transform-sticky-regex": {
+                    "version": "7.0.0-beta.53",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.0.0-beta.53.tgz",
+                    "integrity": "sha1-D888mUq92Lq1m6l4L+TZ+KVF1uc=",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "7.0.0-beta.53",
+                        "@babel/helper-regex": "7.0.0-beta.53"
+                    }
+                },
+                "@babel/plugin-transform-template-literals": {
+                    "version": "7.0.0-beta.53",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.0.0-beta.53.tgz",
+                    "integrity": "sha1-+msLQXEA0j4tsUwd9HorGzl48dk=",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-annotate-as-pure": "7.0.0-beta.53",
+                        "@babel/helper-plugin-utils": "7.0.0-beta.53"
+                    }
+                },
+                "@babel/plugin-transform-typeof-symbol": {
+                    "version": "7.0.0-beta.53",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.0.0-beta.53.tgz",
+                    "integrity": "sha1-ZarocamqQPYRSDZlcxIJrr1cKis=",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "7.0.0-beta.53"
+                    }
+                },
+                "@babel/plugin-transform-unicode-regex": {
+                    "version": "7.0.0-beta.53",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.0.0-beta.53.tgz",
+                    "integrity": "sha1-CvdOyAGefVnji+ZNt/YikZQv7SU=",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-plugin-utils": "7.0.0-beta.53",
+                        "@babel/helper-regex": "7.0.0-beta.53",
+                        "regexpu-core": "^4.1.3"
+                    }
+                },
+                "@babel/template": {
+                    "version": "7.0.0-beta.53",
+                    "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.53.tgz",
+                    "integrity": "sha1-MyIpCQDQsYewpxdDgeHzu3EFDS4=",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "7.0.0-beta.53",
+                        "@babel/parser": "7.0.0-beta.53",
+                        "@babel/types": "7.0.0-beta.53",
+                        "lodash": "^4.17.5"
+                    }
+                },
+                "@babel/traverse": {
+                    "version": "7.0.0-beta.53",
+                    "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.53.tgz",
+                    "integrity": "sha1-ANMs2NC1j0wB0xFXvmIsZigm00Q=",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "7.0.0-beta.53",
+                        "@babel/generator": "7.0.0-beta.53",
+                        "@babel/helper-function-name": "7.0.0-beta.53",
+                        "@babel/helper-split-export-declaration": "7.0.0-beta.53",
+                        "@babel/parser": "7.0.0-beta.53",
+                        "@babel/types": "7.0.0-beta.53",
+                        "debug": "^3.1.0",
+                        "globals": "^11.1.0",
+                        "invariant": "^2.2.0",
+                        "lodash": "^4.17.5"
+                    }
+                },
+                "@babel/types": {
+                    "version": "7.0.0-beta.53",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.53.tgz",
+                    "integrity": "sha1-GaRhwNpRVZXftnQLS0Xce7Dms3U=",
+                    "dev": true,
+                    "requires": {
+                        "esutils": "^2.0.2",
+                        "lodash": "^4.17.5",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                },
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^1.9.0"
+                    }
+                },
+                "chalk": {
+                    "version": "2.4.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+                    "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "1.9.3",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+                    "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "1.1.3"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+                    "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+                    "dev": true
+                },
+                "debug": {
+                    "version": "3.2.7",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+                    "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "has-flag": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+                    "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+                    "dev": true
+                },
+                "js-tokens": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+                    "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+                    "dev": true
+                },
+                "ms": {
+                    "version": "2.1.3",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+                    "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+                    "dev": true
+                },
+                "regenerate-unicode-properties": {
+                    "version": "9.0.0",
+                    "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-9.0.0.tgz",
+                    "integrity": "sha512-3E12UeNSPfjrgwjkR81m5J7Aw/T55Tu7nUyZVQYCKEOs+2dkxEY+DpPtZzO4YruuiPb7NkYLVcyJC4+zCbk5pA==",
+                    "dev": true,
+                    "requires": {
+                        "regenerate": "^1.4.2"
+                    }
+                },
+                "regenerator-transform": {
+                    "version": "0.13.4",
+                    "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.13.4.tgz",
+                    "integrity": "sha512-T0QMBjK3J0MtxjPmdIMXm72Wvj2Abb0Bd4HADdfijwMdoIsyQZ6fWC7kDFhk2YinBBEMZDL7Y7wh0J1sGx3S4A==",
+                    "dev": true,
+                    "requires": {
+                        "private": "^0.1.6"
+                    }
+                },
+                "regexpu-core": {
+                    "version": "4.8.0",
+                    "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.8.0.tgz",
+                    "integrity": "sha512-1F6bYsoYiz6is+oz70NWur2Vlh9KWtswuRuzJOfeYUrfPX2o8n74AnUVaOGDbUqVGO9fNHu48/pjJO4sNVwsOg==",
+                    "dev": true,
+                    "requires": {
+                        "regenerate": "^1.4.2",
+                        "regenerate-unicode-properties": "^9.0.0",
+                        "regjsgen": "^0.5.2",
+                        "regjsparser": "^0.7.0",
+                        "unicode-match-property-ecmascript": "^2.0.0",
+                        "unicode-match-property-value-ecmascript": "^2.0.0"
+                    }
+                },
+                "regjsgen": {
+                    "version": "0.5.2",
+                    "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.5.2.tgz",
+                    "integrity": "sha512-OFFT3MfrH90xIW8OOSyUrk6QHD5E9JOTeGodiJeBS3J6IwlgzJMNE/1bZklWz5oTg+9dCMyEetclvCVXOPoN3A==",
+                    "dev": true
+                },
+                "regjsparser": {
+                    "version": "0.7.0",
+                    "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.7.0.tgz",
+                    "integrity": "sha512-A4pcaORqmNMDVwUjWoTzuhwMGpP+NykpfqAsEgI1FSH/EzC7lrN5TMd+kN8YCovX+jMpu8eaqXgXPCa0g8FQNQ==",
+                    "dev": true,
+                    "requires": {
+                        "jsesc": "~0.5.0"
+                    },
+                    "dependencies": {
+                        "jsesc": {
+                            "version": "0.5.0",
+                            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+                            "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+                            "dev": true
+                        }
+                    }
+                },
+                "supports-color": {
+                    "version": "5.5.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                }
+            }
+        },
+        "@babel/preset-modules": {
+            "version": "0.1.5",
+            "resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.5.tgz",
+            "integrity": "sha512-A57th6YRG7oR3cq/yt/Y84MvGgE0eJG2F1JLhKuyG+jFxEgrd/HAMJatiFtmOiZurz+0DkrvbheCLaV5f2JfjA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/plugin-proposal-unicode-property-regex": "^7.4.4",
+                "@babel/plugin-transform-dotall-regex": "^7.4.4",
+                "@babel/types": "^7.4.4",
+                "esutils": "^2.0.2"
+            }
+        },
+        "@babel/runtime": {
+            "version": "7.17.2",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.2.tgz",
+            "integrity": "sha512-hzeyJyMA1YGdJTuWU0e/j4wKXrU4OMFvY2MSlaI9B7VQb0r5cxTE3EAIS2Q7Tn2RIcDkRvTA/v2JsAEhxe99uw==",
+            "dev": true,
+            "requires": {
+                "regenerator-runtime": "^0.13.4"
+            }
+        },
+        "@babel/template": {
+            "version": "7.16.7",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.16.7.tgz",
+            "integrity": "sha512-I8j/x8kHUrbYRTUxXrrMbfCa7jxkE7tZre39x3kjr9hvI82cK1FfqLygotcWN5kdPGWcLdWMHpSBavse5tWw3w==",
+            "dev": true,
+            "requires": {
+                "@babel/code-frame": "^7.16.7",
+                "@babel/parser": "^7.16.7",
+                "@babel/types": "^7.16.7"
+            }
+        },
+        "@babel/traverse": {
+            "version": "7.17.3",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.17.3.tgz",
+            "integrity": "sha512-5irClVky7TxRWIRtxlh2WPUUOLhcPN06AGgaQSB8AEwuyEBgJVuJ5imdHm5zxk8w0QS5T+tDfnDxAlhWjpb7cw==",
+            "dev": true,
+            "requires": {
+                "@babel/code-frame": "^7.16.7",
+                "@babel/generator": "^7.17.3",
+                "@babel/helper-environment-visitor": "^7.16.7",
+                "@babel/helper-function-name": "^7.16.7",
+                "@babel/helper-hoist-variables": "^7.16.7",
+                "@babel/helper-split-export-declaration": "^7.16.7",
+                "@babel/parser": "^7.17.3",
+                "@babel/types": "^7.17.0",
+                "debug": "^4.1.0",
+                "globals": "^11.1.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "4.3.3",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+                    "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.1.2"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                    "dev": true
+                }
+            }
+        },
+        "@babel/types": {
+            "version": "7.17.0",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.0.tgz",
+            "integrity": "sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-validator-identifier": "^7.16.7",
+                "to-fast-properties": "^2.0.0"
+            }
+        },
+        "@eslint/eslintrc": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.2.0.tgz",
+            "integrity": "sha512-igm9SjJHNEJRiUnecP/1R5T3wKLEJ7pL6e2P+GUSfCd0dGjPYYZve08uzw8L2J8foVHFz+NGu12JxRcU2gGo6w==",
+            "dev": true,
+            "requires": {
+                "ajv": "^6.12.4",
+                "debug": "^4.3.2",
+                "espree": "^9.3.1",
+                "globals": "^13.9.0",
+                "ignore": "^4.0.6",
+                "import-fresh": "^3.2.1",
+                "js-yaml": "^4.1.0",
+                "minimatch": "^3.0.4",
+                "strip-json-comments": "^3.1.1"
+            },
+            "dependencies": {
+                "argparse": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+                    "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+                    "dev": true
+                },
+                "debug": {
+                    "version": "4.3.3",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+                    "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.1.2"
+                    }
+                },
+                "globals": {
+                    "version": "13.12.1",
+                    "resolved": "https://registry.npmjs.org/globals/-/globals-13.12.1.tgz",
+                    "integrity": "sha512-317dFlgY2pdJZ9rspXDks7073GpDmXdfbM3vYYp0HAMKGDh1FfWPleI2ljVNLQX5M5lXcAslTcPTrOrMEFOjyw==",
+                    "dev": true,
+                    "requires": {
+                        "type-fest": "^0.20.2"
+                    }
+                },
+                "ignore": {
+                    "version": "4.0.6",
+                    "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+                    "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+                    "dev": true
+                },
+                "js-yaml": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+                    "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+                    "dev": true,
+                    "requires": {
+                        "argparse": "^2.0.1"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                    "dev": true
+                },
+                "strip-json-comments": {
+                    "version": "3.1.1",
+                    "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+                    "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+                    "dev": true
+                }
+            }
+        },
+        "@humanwhocodes/config-array": {
+            "version": "0.9.5",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.5.tgz",
+            "integrity": "sha512-ObyMyWxZiCu/yTisA7uzx81s40xR2fD5Cg/2Kq7G02ajkNubJf6BopgDTmDyc3U7sXpNKM8cYOw7s7Tyr+DnCw==",
+            "dev": true,
+            "requires": {
+                "@humanwhocodes/object-schema": "^1.2.1",
+                "debug": "^4.1.1",
+                "minimatch": "^3.0.4"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "4.3.3",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+                    "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.1.2"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                    "dev": true
+                }
+            }
+        },
+        "@humanwhocodes/object-schema": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
+            "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
+            "dev": true
+        },
+        "@jridgewell/resolve-uri": {
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.5.tgz",
+            "integrity": "sha512-VPeQ7+wH0itvQxnG+lIzWgkysKIr3L9sslimFW55rHMdGu/qCQ5z5h9zq4gI8uBtqkpHhsF4Z/OwExufUCThew==",
+            "dev": true
+        },
+        "@jridgewell/sourcemap-codec": {
+            "version": "1.4.11",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.11.tgz",
+            "integrity": "sha512-Fg32GrJo61m+VqYSdRSjRXMjQ06j8YIYfcTqndLYVAaHmroZHLJZCydsWBOTDqXS2v+mjxohBWEMfg97GXmYQg==",
+            "dev": true
+        },
+        "@jridgewell/trace-mapping": {
+            "version": "0.3.4",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.4.tgz",
+            "integrity": "sha512-vFv9ttIedivx0ux3QSjhgtCVjPZd5l46ZOMDSCwnH1yUO2e964gO8LZGyv2QkqcgR6TnBU1v+1IFqmeoG+0UJQ==",
+            "dev": true,
+            "requires": {
+                "@jridgewell/resolve-uri": "^3.0.3",
+                "@jridgewell/sourcemap-codec": "^1.4.10"
+            }
+        },
+        "@nicolo-ribaudo/chokidar-2": {
+            "version": "2.1.8-no-fsevents.3",
+            "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/chokidar-2/-/chokidar-2-2.1.8-no-fsevents.3.tgz",
+            "integrity": "sha512-s88O1aVtXftvp5bCPB7WnmXc5IwOZZ7YPuwNPt+GtOOXpPvad1LfbmjYv+qII7zP6RU2QGnqve27dnLycEnyEQ==",
+            "dev": true,
+            "optional": true
+        },
+        "@types/eslint": {
+            "version": "8.4.1",
+            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.1.tgz",
+            "integrity": "sha512-GE44+DNEyxxh2Kc6ro/VkIj+9ma0pO0bwv9+uHSyBrikYOHr8zYcdPvnBOp1aw8s+CjRvuSx7CyWqRrNFQ59mA==",
+            "dev": true,
+            "requires": {
+                "@types/estree": "*",
+                "@types/json-schema": "*"
+            }
+        },
+        "@types/estree": {
+            "version": "0.0.51",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
+            "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
+            "dev": true
+        },
+        "@types/json-schema": {
+            "version": "7.0.9",
+            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
+            "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==",
+            "dev": true
+        },
+        "JSONStream": {
+            "version": "1.3.5",
+            "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
+            "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
+            "dev": true,
+            "requires": {
+                "jsonparse": "^1.2.0",
+                "through": ">=2.2.7 <3"
+            }
+        },
+        "abbrev": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+            "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+            "dev": true
+        },
+        "acorn": {
+            "version": "7.4.1",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+            "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+            "dev": true
+        },
+        "acorn-jsx": {
+            "version": "5.3.2",
+            "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+            "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+            "dev": true
+        },
+        "acorn-node": {
+            "version": "1.8.2",
+            "resolved": "https://registry.npmjs.org/acorn-node/-/acorn-node-1.8.2.tgz",
+            "integrity": "sha512-8mt+fslDufLYntIoPAaIMUe/lrbrehIiwmR3t2k9LljIzoigEPF27eLk2hy8zSGzmR/ogr7zbRKINMo1u0yh5A==",
+            "dev": true,
+            "requires": {
+                "acorn": "^7.0.0",
+                "acorn-walk": "^7.0.0",
+                "xtend": "^4.0.2"
+            }
+        },
+        "acorn-walk": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
+            "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==",
+            "dev": true
+        },
+        "ajv": {
+            "version": "6.12.6",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+            "dev": true,
+            "requires": {
+                "fast-deep-equal": "^3.1.1",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
+            }
+        },
+        "ansi-regex": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+            "dev": true
+        },
+        "ansi-styles": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+            "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+            "dev": true
+        },
+        "anymatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
+            "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+            "dev": true,
+            "requires": {
+                "normalize-path": "^3.0.0",
+                "picomatch": "^2.0.4"
+            }
+        },
+        "argparse": {
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+            "dev": true,
+            "requires": {
+                "sprintf-js": "~1.0.2"
+            },
+            "dependencies": {
+                "sprintf-js": {
+                    "version": "1.0.3",
+                    "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+                    "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+                    "dev": true
+                }
+            }
+        },
+        "arr-diff": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+            "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+            "dev": true,
+            "requires": {
+                "arr-flatten": "^1.0.1"
+            }
+        },
+        "arr-flatten": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+            "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+            "dev": true
+        },
+        "arr-union": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+            "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+            "dev": true
+        },
+        "array-each": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/array-each/-/array-each-1.0.1.tgz",
+            "integrity": "sha1-p5SvDAWrF1KEbudTofIRoFugxE8=",
+            "dev": true
+        },
+        "array-slice": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-1.1.0.tgz",
+            "integrity": "sha512-B1qMD3RBP7O8o0H2KbrXDyB0IccejMF15+87Lvlor12ONPRHP6gTjXMNkt/d3ZuOGbAe66hFmaCfECI24Ufp6w==",
+            "dev": true
+        },
+        "array-unique": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+            "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+            "dev": true
+        },
+        "asn1.js": {
+            "version": "5.4.1",
+            "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+            "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+            "dev": true,
+            "requires": {
+                "bn.js": "^4.0.0",
+                "inherits": "^2.0.1",
+                "minimalistic-assert": "^1.0.0",
+                "safer-buffer": "^2.1.0"
+            },
+            "dependencies": {
+                "bn.js": {
+                    "version": "4.12.0",
+                    "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+                    "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+                    "dev": true
+                }
+            }
+        },
+        "assert": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/assert/-/assert-1.5.0.tgz",
+            "integrity": "sha512-EDsgawzwoun2CZkCgtxJbv392v4nbk9XDD06zI+kQYoBM/3RBWLlEyJARDOmhAAosBjWACEkKL6S+lIZtcAubA==",
+            "dev": true,
+            "requires": {
+                "object-assign": "^4.1.1",
+                "util": "0.10.3"
+            },
+            "dependencies": {
+                "inherits": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                    "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+                    "dev": true
+                },
+                "util": {
+                    "version": "0.10.3",
+                    "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+                    "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
+                    "dev": true,
+                    "requires": {
+                        "inherits": "2.0.1"
+                    }
+                }
+            }
+        },
+        "assign-symbols": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+            "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+            "dev": true
+        },
+        "async": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
+            "integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g==",
+            "dev": true
+        },
+        "async-each": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
+            "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
+            "dev": true
+        },
+        "atob": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+            "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+            "dev": true
+        },
+        "available-typed-arrays": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
+            "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
+            "dev": true
+        },
+        "babel-plugin-dynamic-import-node": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz",
+            "integrity": "sha512-jZVI+s9Zg3IqA/kdi0i6UDCybUI3aSBLnglhYbSSjKlV7yF1F/5LWv8MakQmvYpnbJDS6fcBL2KzHSxNCMtWSQ==",
+            "dev": true,
+            "requires": {
+                "object.assign": "^4.1.0"
+            }
+        },
+        "babel-plugin-polyfill-corejs2": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.3.1.tgz",
+            "integrity": "sha512-v7/T6EQcNfVLfcN2X8Lulb7DjprieyLWJK/zOWH5DUYcAgex9sP3h25Q+DLsX9TloXe3y1O8l2q2Jv9q8UVB9w==",
+            "dev": true,
+            "requires": {
+                "@babel/compat-data": "^7.13.11",
+                "@babel/helper-define-polyfill-provider": "^0.3.1",
+                "semver": "^6.1.1"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+                    "dev": true
+                }
+            }
+        },
+        "babel-plugin-polyfill-corejs3": {
+            "version": "0.5.2",
+            "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.5.2.tgz",
+            "integrity": "sha512-G3uJih0XWiID451fpeFaYGVuxHEjzKTHtc9uGFEjR6hHrvNzeS/PX+LLLcetJcytsB5m4j+K3o/EpXJNb/5IEQ==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-define-polyfill-provider": "^0.3.1",
+                "core-js-compat": "^3.21.0"
+            }
+        },
+        "babel-plugin-polyfill-regenerator": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.3.1.tgz",
+            "integrity": "sha512-Y2B06tvgHYt1x0yz17jGkGeeMr5FeKUu+ASJ+N6nB5lQ8Dapfg42i0OVrf8PNGJ3zKL4A23snMi1IRwrqqND7A==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-define-polyfill-provider": "^0.3.1"
+            }
+        },
+        "babelify": {
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/babelify/-/babelify-10.0.0.tgz",
+            "integrity": "sha512-X40FaxyH7t3X+JFAKvb1H9wooWKLRCi8pg3m8poqtdZaIng+bjzp9RvKQCvRjF9isHiPkXspbbXT/zwXLtwgwg==",
+            "dev": true
+        },
+        "balanced-match": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "dev": true
+        },
+        "base": {
+            "version": "0.11.2",
+            "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
+            "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+            "dev": true,
+            "requires": {
+                "cache-base": "^1.0.1",
+                "class-utils": "^0.3.5",
+                "component-emitter": "^1.2.1",
+                "define-property": "^1.0.0",
+                "isobject": "^3.0.1",
+                "mixin-deep": "^1.2.0",
+                "pascalcase": "^0.1.1"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+                    "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+                    "dev": true,
+                    "requires": {
+                        "is-descriptor": "^1.0.0"
+                    }
+                },
+                "is-accessor-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-data-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-descriptor": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+                    "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+                    "dev": true,
+                    "requires": {
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
+                    }
+                }
+            }
+        },
+        "base64-js": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+            "dev": true
+        },
+        "binary-extensions": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+            "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+            "dev": true
+        },
+        "bindings": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+            "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+            "dev": true,
+            "optional": true,
+            "requires": {
+                "file-uri-to-path": "1.0.0"
+            }
+        },
+        "bn.js": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
+            "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw==",
+            "dev": true
+        },
+        "brace-expansion": {
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "dev": true,
+            "requires": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "braces": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+            "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+            "dev": true,
+            "requires": {
+                "fill-range": "^7.0.1"
+            }
+        },
+        "brorand": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+            "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
+            "dev": true
+        },
+        "browser-pack": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-6.1.0.tgz",
+            "integrity": "sha512-erYug8XoqzU3IfcU8fUgyHqyOXqIE4tUTTQ+7mqUjQlvnXkOO6OlT9c/ZoJVHYoAaqGxr09CN53G7XIsO4KtWA==",
+            "dev": true,
+            "requires": {
+                "JSONStream": "^1.0.3",
+                "combine-source-map": "~0.8.0",
+                "defined": "^1.0.0",
+                "safe-buffer": "^5.1.1",
+                "through2": "^2.0.0",
+                "umd": "^3.0.0"
+            }
+        },
+        "browser-resolve": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-2.0.0.tgz",
+            "integrity": "sha512-7sWsQlYL2rGLy2IWm8WL8DCTJvYLc/qlOnsakDac87SOoCd16WLsaAMdCiAqsTNHIe+SXfaqyxyo6THoWqs8WQ==",
+            "dev": true,
+            "requires": {
+                "resolve": "^1.17.0"
+            }
+        },
+        "browserify": {
+            "version": "16.5.2",
+            "resolved": "https://registry.npmjs.org/browserify/-/browserify-16.5.2.tgz",
+            "integrity": "sha512-TkOR1cQGdmXU9zW4YukWzWVSJwrxmNdADFbqbE3HFgQWe5wqZmOawqZ7J/8MPCwk/W8yY7Y0h+7mOtcZxLP23g==",
+            "dev": true,
+            "requires": {
+                "JSONStream": "^1.0.3",
+                "assert": "^1.4.0",
+                "browser-pack": "^6.0.1",
+                "browser-resolve": "^2.0.0",
+                "browserify-zlib": "~0.2.0",
+                "buffer": "~5.2.1",
+                "cached-path-relative": "^1.0.0",
+                "concat-stream": "^1.6.0",
+                "console-browserify": "^1.1.0",
+                "constants-browserify": "~1.0.0",
+                "crypto-browserify": "^3.0.0",
+                "defined": "^1.0.0",
+                "deps-sort": "^2.0.0",
+                "domain-browser": "^1.2.0",
+                "duplexer2": "~0.1.2",
+                "events": "^2.0.0",
+                "glob": "^7.1.0",
+                "has": "^1.0.0",
+                "htmlescape": "^1.1.0",
+                "https-browserify": "^1.0.0",
+                "inherits": "~2.0.1",
+                "insert-module-globals": "^7.0.0",
+                "labeled-stream-splicer": "^2.0.0",
+                "mkdirp-classic": "^0.5.2",
+                "module-deps": "^6.2.3",
+                "os-browserify": "~0.3.0",
+                "parents": "^1.0.1",
+                "path-browserify": "~0.0.0",
+                "process": "~0.11.0",
+                "punycode": "^1.3.2",
+                "querystring-es3": "~0.2.0",
+                "read-only-stream": "^2.0.0",
+                "readable-stream": "^2.0.2",
+                "resolve": "^1.1.4",
+                "shasum": "^1.0.0",
+                "shell-quote": "^1.6.1",
+                "stream-browserify": "^2.0.0",
+                "stream-http": "^3.0.0",
+                "string_decoder": "^1.1.1",
+                "subarg": "^1.0.0",
+                "syntax-error": "^1.1.1",
+                "through2": "^2.0.0",
+                "timers-browserify": "^1.0.1",
+                "tty-browserify": "0.0.1",
+                "url": "~0.11.0",
+                "util": "~0.10.1",
+                "vm-browserify": "^1.0.0",
+                "xtend": "^4.0.0"
+            }
+        },
+        "browserify-aes": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+            "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
+            "dev": true,
+            "requires": {
+                "buffer-xor": "^1.0.3",
+                "cipher-base": "^1.0.0",
+                "create-hash": "^1.1.0",
+                "evp_bytestokey": "^1.0.3",
+                "inherits": "^2.0.1",
+                "safe-buffer": "^5.0.1"
+            }
+        },
+        "browserify-cache-api": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/browserify-cache-api/-/browserify-cache-api-3.0.1.tgz",
+            "integrity": "sha1-liR+hT8Gj9bg1FzHPwuyzZd47wI=",
+            "dev": true,
+            "requires": {
+                "async": "^1.5.2",
+                "through2": "^2.0.0",
+                "xtend": "^4.0.0"
+            },
+            "dependencies": {
+                "async": {
+                    "version": "1.5.2",
+                    "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+                    "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+                    "dev": true
+                }
+            }
+        },
+        "browserify-cipher": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
+            "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
+            "dev": true,
+            "requires": {
+                "browserify-aes": "^1.0.4",
+                "browserify-des": "^1.0.0",
+                "evp_bytestokey": "^1.0.0"
+            }
+        },
+        "browserify-des": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
+            "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
+            "dev": true,
+            "requires": {
+                "cipher-base": "^1.0.1",
+                "des.js": "^1.0.0",
+                "inherits": "^2.0.1",
+                "safe-buffer": "^5.1.2"
+            }
+        },
+        "browserify-incremental": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/browserify-incremental/-/browserify-incremental-3.1.1.tgz",
+            "integrity": "sha1-BxPLdYckemMqnwjPG9FpuHi2Koo=",
+            "dev": true,
+            "requires": {
+                "JSONStream": "^0.10.0",
+                "browserify-cache-api": "^3.0.0",
+                "through2": "^2.0.0",
+                "xtend": "^4.0.0"
+            },
+            "dependencies": {
+                "JSONStream": {
+                    "version": "0.10.0",
+                    "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.10.0.tgz",
+                    "integrity": "sha1-dDSdDYlSK3HzDwoD/5vSDKbxKsA=",
+                    "dev": true,
+                    "requires": {
+                        "jsonparse": "0.0.5",
+                        "through": ">=2.2.7 <3"
+                    }
+                },
+                "jsonparse": {
+                    "version": "0.0.5",
+                    "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz",
+                    "integrity": "sha1-MwVCrT8KZUZlt3jz6y2an6UHrGQ=",
+                    "dev": true
+                }
+            }
+        },
+        "browserify-rsa": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.1.0.tgz",
+            "integrity": "sha512-AdEER0Hkspgno2aR97SAf6vi0y0k8NuOpGnVH3O99rcA5Q6sh8QxcngtHuJ6uXwnfAXNM4Gn1Gb7/MV1+Ymbog==",
+            "dev": true,
+            "requires": {
+                "bn.js": "^5.0.0",
+                "randombytes": "^2.0.1"
+            }
+        },
+        "browserify-sign": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.1.tgz",
+            "integrity": "sha512-/vrA5fguVAKKAVTNJjgSm1tRQDHUU6DbwO9IROu/0WAzC8PKhucDSh18J0RMvVeHAn5puMd+QHC2erPRNf8lmg==",
+            "dev": true,
+            "requires": {
+                "bn.js": "^5.1.1",
+                "browserify-rsa": "^4.0.1",
+                "create-hash": "^1.2.0",
+                "create-hmac": "^1.1.7",
+                "elliptic": "^6.5.3",
+                "inherits": "^2.0.4",
+                "parse-asn1": "^5.1.5",
+                "readable-stream": "^3.6.0",
+                "safe-buffer": "^5.2.0"
+            },
+            "dependencies": {
+                "readable-stream": {
+                    "version": "3.6.0",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+                    "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+                    "dev": true,
+                    "requires": {
+                        "inherits": "^2.0.3",
+                        "string_decoder": "^1.1.1",
+                        "util-deprecate": "^1.0.1"
+                    }
+                }
+            }
+        },
+        "browserify-zlib": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+            "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+            "dev": true,
+            "requires": {
+                "pako": "~1.0.5"
+            }
+        },
+        "browserslist": {
+            "version": "4.19.3",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.19.3.tgz",
+            "integrity": "sha512-XK3X4xtKJ+Txj8G5c30B4gsm71s69lqXlkYui4s6EkKxuv49qjYlY6oVd+IFJ73d4YymtM3+djvvt/R/iJwwDg==",
+            "dev": true,
+            "requires": {
+                "caniuse-lite": "^1.0.30001312",
+                "electron-to-chromium": "^1.4.71",
+                "escalade": "^3.1.1",
+                "node-releases": "^2.0.2",
+                "picocolors": "^1.0.0"
+            }
+        },
+        "buffer": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.2.1.tgz",
+            "integrity": "sha512-c+Ko0loDaFfuPWiL02ls9Xd3GO3cPVmUobQ6t3rXNUk304u6hGq+8N/kFi+QEIKhzK3uwolVhLzszmfLmMLnqg==",
+            "dev": true,
+            "requires": {
+                "base64-js": "^1.0.2",
+                "ieee754": "^1.1.4"
+            }
+        },
+        "buffer-from": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+            "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+            "dev": true
+        },
+        "buffer-xor": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+            "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
+            "dev": true
+        },
+        "builtin-status-codes": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
+            "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
+            "dev": true
+        },
+        "cache-base": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+            "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+            "dev": true,
+            "requires": {
+                "collection-visit": "^1.0.0",
+                "component-emitter": "^1.2.1",
+                "get-value": "^2.0.6",
+                "has-value": "^1.0.0",
+                "isobject": "^3.0.1",
+                "set-value": "^2.0.0",
+                "to-object-path": "^0.3.0",
+                "union-value": "^1.0.0",
+                "unset-value": "^1.0.0"
+            }
+        },
+        "cached-path-relative": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/cached-path-relative/-/cached-path-relative-1.1.0.tgz",
+            "integrity": "sha512-WF0LihfemtesFcJgO7xfOoOcnWzY/QHR4qeDqV44jPU3HTI54+LnfXK3SA27AVVGCdZFgjjFFaqUA9Jx7dMJZA==",
+            "dev": true
+        },
+        "call-bind": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+            "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+            "dev": true,
+            "requires": {
+                "function-bind": "^1.1.1",
+                "get-intrinsic": "^1.0.2"
+            }
+        },
+        "callsites": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+            "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+            "dev": true
+        },
+        "caniuse-lite": {
+            "version": "1.0.30001313",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001313.tgz",
+            "integrity": "sha512-rI1UN0koZUiKINjysQDuRi2VeSCce3bYJNmDcj3PIKREiAmjakugBul1QSkg/fPrlULYl6oWfGg3PbgOSY9X4Q==",
+            "dev": true
+        },
+        "chalk": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+            "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+            "dev": true,
+            "requires": {
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
+            }
+        },
+        "chokidar": {
+            "version": "3.5.3",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+            "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+            "dev": true,
+            "requires": {
+                "anymatch": "~3.1.2",
+                "braces": "~3.0.2",
+                "fsevents": "~2.3.2",
+                "glob-parent": "~5.1.2",
+                "is-binary-path": "~2.1.0",
+                "is-glob": "~4.0.1",
+                "normalize-path": "~3.0.0",
+                "readdirp": "~3.6.0"
+            }
+        },
+        "cipher-base": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+            "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+            "dev": true,
+            "requires": {
+                "inherits": "^2.0.1",
+                "safe-buffer": "^5.0.1"
+            }
+        },
+        "class-utils": {
+            "version": "0.3.6",
+            "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
+            "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+            "dev": true,
+            "requires": {
+                "arr-union": "^3.1.0",
+                "define-property": "^0.2.5",
+                "isobject": "^3.0.0",
+                "static-extend": "^0.1.1"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "0.2.5",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+                    "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                    "dev": true,
+                    "requires": {
+                        "is-descriptor": "^0.1.0"
+                    }
+                }
+            }
+        },
+        "clone": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+            "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+            "dev": true
+        },
+        "clone-buffer": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
+            "integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg=",
+            "dev": true
+        },
+        "clone-stats": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
+            "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
+            "dev": true
+        },
+        "cloneable-readable": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.1.3.tgz",
+            "integrity": "sha512-2EF8zTQOxYq70Y4XKtorQupqF0m49MBz2/yf5Bj+MHjvpG3Hy7sImifnqD6UA+TKYxeSV+u6qqQPawN5UvnpKQ==",
+            "dev": true,
+            "requires": {
+                "inherits": "^2.0.1",
+                "process-nextick-args": "^2.0.0",
+                "readable-stream": "^2.3.5"
+            }
+        },
+        "collection-visit": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+            "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+            "dev": true,
+            "requires": {
+                "map-visit": "^1.0.0",
+                "object-visit": "^1.0.0"
+            }
+        },
+        "color-convert": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+            "dev": true,
+            "requires": {
+                "color-name": "~1.1.4"
+            }
+        },
+        "color-name": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+            "dev": true
+        },
+        "colors": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+            "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
+            "dev": true
+        },
+        "combine-source-map": {
+            "version": "0.8.0",
+            "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.8.0.tgz",
+            "integrity": "sha1-pY0N8ELBhvz4IqjoAV9UUNLXmos=",
+            "dev": true,
+            "requires": {
+                "convert-source-map": "~1.1.0",
+                "inline-source-map": "~0.6.0",
+                "lodash.memoize": "~3.0.3",
+                "source-map": "~0.5.3"
+            }
+        },
+        "commander": {
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+            "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+            "dev": true,
+            "requires": {
+                "graceful-readlink": ">= 1.0.0"
+            }
+        },
+        "component-emitter": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+            "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
+            "dev": true
+        },
+        "concat-map": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+            "dev": true
+        },
+        "concat-stream": {
+            "version": "1.6.2",
+            "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+            "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+            "dev": true,
+            "requires": {
+                "buffer-from": "^1.0.0",
+                "inherits": "^2.0.3",
+                "readable-stream": "^2.2.2",
+                "typedarray": "^0.0.6"
+            }
+        },
+        "console-browserify": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz",
+            "integrity": "sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA==",
+            "dev": true
+        },
+        "constants-browserify": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
+            "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
+            "dev": true
+        },
+        "convert-source-map": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
+            "integrity": "sha1-SCnId+n+SbMWHzvzZziI4gRpmGA=",
+            "dev": true
+        },
+        "copy-descriptor": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+            "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+            "dev": true
+        },
+        "core-js-compat": {
+            "version": "3.21.1",
+            "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.21.1.tgz",
+            "integrity": "sha512-gbgX5AUvMb8gwxC7FLVWYT7Kkgu/y7+h/h1X43yJkNqhlK2fuYyQimqvKGNZFAY6CKii/GFKJ2cp/1/42TN36g==",
+            "dev": true,
+            "requires": {
+                "browserslist": "^4.19.1",
+                "semver": "7.0.0"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "7.0.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
+                    "integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==",
+                    "dev": true
+                }
+            }
+        },
+        "core-util-is": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+            "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+            "dev": true
+        },
+        "create-ecdh": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz",
+            "integrity": "sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==",
+            "dev": true,
+            "requires": {
+                "bn.js": "^4.1.0",
+                "elliptic": "^6.5.3"
+            },
+            "dependencies": {
+                "bn.js": {
+                    "version": "4.12.0",
+                    "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+                    "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+                    "dev": true
+                }
+            }
+        },
+        "create-hash": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+            "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+            "dev": true,
+            "requires": {
+                "cipher-base": "^1.0.1",
+                "inherits": "^2.0.1",
+                "md5.js": "^1.3.4",
+                "ripemd160": "^2.0.1",
+                "sha.js": "^2.4.0"
+            }
+        },
+        "create-hmac": {
+            "version": "1.1.7",
+            "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+            "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+            "dev": true,
+            "requires": {
+                "cipher-base": "^1.0.3",
+                "create-hash": "^1.1.0",
+                "inherits": "^2.0.1",
+                "ripemd160": "^2.0.0",
+                "safe-buffer": "^5.0.1",
+                "sha.js": "^2.4.8"
+            }
+        },
+        "cross-spawn": {
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+            "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+            "dev": true,
+            "requires": {
+                "path-key": "^3.1.0",
+                "shebang-command": "^2.0.0",
+                "which": "^2.0.1"
+            },
+            "dependencies": {
+                "which": {
+                    "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+                    "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+                    "dev": true,
+                    "requires": {
+                        "isexe": "^2.0.0"
+                    }
+                }
+            }
+        },
+        "crypto-browserify": {
+            "version": "3.12.0",
+            "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
+            "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
+            "dev": true,
+            "requires": {
+                "browserify-cipher": "^1.0.0",
+                "browserify-sign": "^4.0.0",
+                "create-ecdh": "^4.0.0",
+                "create-hash": "^1.1.0",
+                "create-hmac": "^1.1.0",
+                "diffie-hellman": "^5.0.0",
+                "inherits": "^2.0.1",
+                "pbkdf2": "^3.0.3",
+                "public-encrypt": "^4.0.0",
+                "randombytes": "^2.0.0",
+                "randomfill": "^1.0.3"
+            }
+        },
+        "dash-ast": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/dash-ast/-/dash-ast-1.0.0.tgz",
+            "integrity": "sha512-Vy4dx7gquTeMcQR/hDkYLGUnwVil6vk4FOOct+djUnHOUWt+zJPJAaRIXaAFkPXtJjvlY7o3rfRu0/3hpnwoUA==",
+            "dev": true
+        },
+        "dateformat": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
+            "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==",
+            "dev": true
+        },
+        "debug": {
+            "version": "2.6.9",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+            "dev": true,
+            "requires": {
+                "ms": "2.0.0"
+            }
+        },
+        "decode-uri-component": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+            "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+            "dev": true
+        },
+        "deep-is": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+            "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+            "dev": true
+        },
+        "define-properties": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+            "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+            "dev": true,
+            "requires": {
+                "object-keys": "^1.0.12"
+            }
+        },
+        "define-property": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+            "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+            "dev": true,
+            "requires": {
+                "is-descriptor": "^1.0.2",
+                "isobject": "^3.0.1"
+            },
+            "dependencies": {
+                "is-accessor-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-data-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-descriptor": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+                    "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+                    "dev": true,
+                    "requires": {
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
+                    }
+                }
+            }
+        },
+        "defined": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+            "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
+            "dev": true
+        },
+        "deps-sort": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-2.0.1.tgz",
+            "integrity": "sha512-1orqXQr5po+3KI6kQb9A4jnXT1PBwggGl2d7Sq2xsnOeI9GPcE/tGcF9UiSZtZBM7MukY4cAh7MemS6tZYipfw==",
+            "dev": true,
+            "requires": {
+                "JSONStream": "^1.0.3",
+                "shasum-object": "^1.0.0",
+                "subarg": "^1.0.0",
+                "through2": "^2.0.0"
+            }
+        },
+        "des.js": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.1.tgz",
+            "integrity": "sha512-Q0I4pfFrv2VPd34/vfLrFOoRmlYj3OV50i7fskps1jZWK1kApMWWT9G6RRUeYedLcBDIhnSDaUvJMb3AhUlaEA==",
+            "dev": true,
+            "requires": {
+                "inherits": "^2.0.1",
+                "minimalistic-assert": "^1.0.0"
+            }
+        },
+        "detect-file": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
+            "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=",
+            "dev": true
+        },
+        "detective": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/detective/-/detective-5.2.0.tgz",
+            "integrity": "sha512-6SsIx+nUUbuK0EthKjv0zrdnajCCXVYGmbYYiYjFVpzcjwEs/JMDZ8tPRG29J/HhN56t3GJp2cGSWDRjjot8Pg==",
+            "dev": true,
+            "requires": {
+                "acorn-node": "^1.6.1",
+                "defined": "^1.0.0",
+                "minimist": "^1.1.1"
+            }
+        },
+        "diffie-hellman": {
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+            "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
+            "dev": true,
+            "requires": {
+                "bn.js": "^4.1.0",
+                "miller-rabin": "^4.0.0",
+                "randombytes": "^2.0.0"
+            },
+            "dependencies": {
+                "bn.js": {
+                    "version": "4.12.0",
+                    "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+                    "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+                    "dev": true
+                }
+            }
+        },
+        "doctrine": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+            "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+            "dev": true,
+            "requires": {
+                "esutils": "^2.0.2"
+            }
+        },
+        "domain-browser": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
+            "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA==",
+            "dev": true
+        },
+        "duplexer2": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+            "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
+            "dev": true,
+            "requires": {
+                "readable-stream": "^2.0.2"
+            }
+        },
+        "electron-to-chromium": {
+            "version": "1.4.76",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.76.tgz",
+            "integrity": "sha512-3Vftv7cenJtQb+k00McEBZ2vVmZ/x+HEF7pcZONZIkOsESqAqVuACmBxMv0JhzX7u0YltU0vSqRqgBSTAhFUjA==",
+            "dev": true
+        },
+        "elliptic": {
+            "version": "6.5.4",
+            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+            "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
+            "dev": true,
+            "requires": {
+                "bn.js": "^4.11.9",
+                "brorand": "^1.1.0",
+                "hash.js": "^1.0.0",
+                "hmac-drbg": "^1.0.1",
+                "inherits": "^2.0.4",
+                "minimalistic-assert": "^1.0.1",
+                "minimalistic-crypto-utils": "^1.0.1"
+            },
+            "dependencies": {
+                "bn.js": {
+                    "version": "4.12.0",
+                    "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+                    "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+                    "dev": true
+                }
+            }
+        },
+        "ensure-posix-path": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/ensure-posix-path/-/ensure-posix-path-1.1.1.tgz",
+            "integrity": "sha512-VWU0/zXzVbeJNXvME/5EmLuEj2TauvoaTz6aFYK1Z92JCBlDlZ3Gu0tuGR42kpW1754ywTs+QB0g5TP0oj9Zaw==",
+            "dev": true
+        },
+        "es-abstract": {
+            "version": "1.19.1",
+            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.1.tgz",
+            "integrity": "sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==",
+            "dev": true,
+            "requires": {
+                "call-bind": "^1.0.2",
+                "es-to-primitive": "^1.2.1",
+                "function-bind": "^1.1.1",
+                "get-intrinsic": "^1.1.1",
+                "get-symbol-description": "^1.0.0",
+                "has": "^1.0.3",
+                "has-symbols": "^1.0.2",
+                "internal-slot": "^1.0.3",
+                "is-callable": "^1.2.4",
+                "is-negative-zero": "^2.0.1",
+                "is-regex": "^1.1.4",
+                "is-shared-array-buffer": "^1.0.1",
+                "is-string": "^1.0.7",
+                "is-weakref": "^1.0.1",
+                "object-inspect": "^1.11.0",
+                "object-keys": "^1.1.1",
+                "object.assign": "^4.1.2",
+                "string.prototype.trimend": "^1.0.4",
+                "string.prototype.trimstart": "^1.0.4",
+                "unbox-primitive": "^1.0.1"
+            }
+        },
+        "es-to-primitive": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+            "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+            "dev": true,
+            "requires": {
+                "is-callable": "^1.1.4",
+                "is-date-object": "^1.0.1",
+                "is-symbol": "^1.0.2"
+            }
+        },
+        "escalade": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+            "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+            "dev": true
+        },
+        "escape-string-regexp": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+            "dev": true
+        },
+        "eslint": {
+            "version": "8.10.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.10.0.tgz",
+            "integrity": "sha512-tcI1D9lfVec+R4LE1mNDnzoJ/f71Kl/9Cv4nG47jOueCMBrCCKYXr4AUVS7go6mWYGFD4+EoN6+eXSrEbRzXVw==",
+            "dev": true,
+            "requires": {
+                "@eslint/eslintrc": "^1.2.0",
+                "@humanwhocodes/config-array": "^0.9.2",
+                "ajv": "^6.10.0",
+                "chalk": "^4.0.0",
+                "cross-spawn": "^7.0.2",
+                "debug": "^4.3.2",
+                "doctrine": "^3.0.0",
+                "escape-string-regexp": "^4.0.0",
+                "eslint-scope": "^7.1.1",
+                "eslint-utils": "^3.0.0",
+                "eslint-visitor-keys": "^3.3.0",
+                "espree": "^9.3.1",
+                "esquery": "^1.4.0",
+                "esutils": "^2.0.2",
+                "fast-deep-equal": "^3.1.3",
+                "file-entry-cache": "^6.0.1",
+                "functional-red-black-tree": "^1.0.1",
+                "glob-parent": "^6.0.1",
+                "globals": "^13.6.0",
+                "ignore": "^5.2.0",
+                "import-fresh": "^3.0.0",
+                "imurmurhash": "^0.1.4",
+                "is-glob": "^4.0.0",
+                "js-yaml": "^4.1.0",
+                "json-stable-stringify-without-jsonify": "^1.0.1",
+                "levn": "^0.4.1",
+                "lodash.merge": "^4.6.2",
+                "minimatch": "^3.0.4",
+                "natural-compare": "^1.4.0",
+                "optionator": "^0.9.1",
+                "regexpp": "^3.2.0",
+                "strip-ansi": "^6.0.1",
+                "strip-json-comments": "^3.1.0",
+                "text-table": "^0.2.0",
+                "v8-compile-cache": "^2.0.3"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+                    "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+                    "dev": true
+                },
+                "ansi-styles": {
+                    "version": "4.3.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "argparse": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+                    "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+                    "dev": true
+                },
+                "chalk": {
+                    "version": "4.1.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+                    "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "debug": {
+                    "version": "4.3.3",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+                    "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.1.2"
+                    }
+                },
+                "escape-string-regexp": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+                    "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+                    "dev": true
+                },
+                "glob-parent": {
+                    "version": "6.0.2",
+                    "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+                    "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+                    "dev": true,
+                    "requires": {
+                        "is-glob": "^4.0.3"
+                    }
+                },
+                "globals": {
+                    "version": "13.12.1",
+                    "resolved": "https://registry.npmjs.org/globals/-/globals-13.12.1.tgz",
+                    "integrity": "sha512-317dFlgY2pdJZ9rspXDks7073GpDmXdfbM3vYYp0HAMKGDh1FfWPleI2ljVNLQX5M5lXcAslTcPTrOrMEFOjyw==",
+                    "dev": true,
+                    "requires": {
+                        "type-fest": "^0.20.2"
+                    }
+                },
+                "js-yaml": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+                    "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+                    "dev": true,
+                    "requires": {
+                        "argparse": "^2.0.1"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                    "dev": true
+                },
+                "strip-ansi": {
+                    "version": "6.0.1",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+                    "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^5.0.1"
+                    }
+                },
+                "strip-json-comments": {
+                    "version": "3.1.1",
+                    "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+                    "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
+            }
+        },
+        "eslint-scope": {
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
+            "integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
+            "dev": true,
+            "requires": {
+                "esrecurse": "^4.3.0",
+                "estraverse": "^5.2.0"
+            }
+        },
+        "eslint-utils": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+            "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+            "dev": true,
+            "requires": {
+                "eslint-visitor-keys": "^2.0.0"
+            },
+            "dependencies": {
+                "eslint-visitor-keys": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+                    "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+                    "dev": true
+                }
+            }
+        },
+        "eslint-visitor-keys": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+            "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+            "dev": true
+        },
+        "espree": {
+            "version": "9.3.1",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.1.tgz",
+            "integrity": "sha512-bvdyLmJMfwkV3NCRl5ZhJf22zBFo1y8bYh3VYb+bfzqNB4Je68P2sSuXyuFquzWLebHpNd2/d5uv7yoP9ISnGQ==",
+            "dev": true,
+            "requires": {
+                "acorn": "^8.7.0",
+                "acorn-jsx": "^5.3.1",
+                "eslint-visitor-keys": "^3.3.0"
+            },
+            "dependencies": {
+                "acorn": {
+                    "version": "8.7.0",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
+                    "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
+                    "dev": true
+                }
+            }
+        },
+        "esprima": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+            "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+            "dev": true
+        },
+        "esquery": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
+            "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
+            "dev": true,
+            "requires": {
+                "estraverse": "^5.1.0"
+            }
+        },
+        "esrecurse": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+            "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+            "dev": true,
+            "requires": {
+                "estraverse": "^5.2.0"
+            }
+        },
+        "estraverse": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+            "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+            "dev": true
+        },
+        "esutils": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+            "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+            "dev": true
+        },
+        "eventemitter2": {
+            "version": "0.4.14",
+            "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
+            "integrity": "sha1-j2G3XN4BKy6esoTUVFWDtWQ7Yas=",
+            "dev": true
+        },
+        "events": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/events/-/events-2.1.0.tgz",
+            "integrity": "sha512-3Zmiobend8P9DjmKAty0Era4jV8oJ0yGYe2nJJAxgymF9+N8F2m0hhZiMoWtcfepExzNKZumFU3ksdQbInGWCg==",
+            "dev": true
+        },
+        "evp_bytestokey": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
+            "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+            "dev": true,
+            "requires": {
+                "md5.js": "^1.3.4",
+                "safe-buffer": "^5.1.1"
+            }
+        },
+        "exists-stat": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/exists-stat/-/exists-stat-1.0.0.tgz",
+            "integrity": "sha1-BmDjUlouidnkRhKUQMJy7foktSk=",
+            "dev": true
+        },
+        "exit": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+            "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+            "dev": true
+        },
+        "expand-brackets": {
+            "version": "0.1.5",
+            "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+            "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+            "dev": true,
+            "requires": {
+                "is-posix-bracket": "^0.1.0"
+            }
+        },
+        "expand-range": {
+            "version": "1.8.2",
+            "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+            "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+            "dev": true,
+            "requires": {
+                "fill-range": "^2.1.0"
+            },
+            "dependencies": {
+                "fill-range": {
+                    "version": "2.2.4",
+                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
+                    "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
+                    "dev": true,
+                    "requires": {
+                        "is-number": "^2.1.0",
+                        "isobject": "^2.0.0",
+                        "randomatic": "^3.0.0",
+                        "repeat-element": "^1.1.2",
+                        "repeat-string": "^1.5.2"
+                    }
+                },
+                "is-number": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+                    "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^3.0.2"
+                    }
+                },
+                "isobject": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+                    "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+                    "dev": true,
+                    "requires": {
+                        "isarray": "1.0.0"
+                    }
+                },
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "^1.1.5"
+                    }
+                }
+            }
+        },
+        "expand-tilde": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
+            "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
+            "dev": true,
+            "requires": {
+                "homedir-polyfill": "^1.0.1"
+            }
+        },
+        "extend": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+            "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+            "dev": true
+        },
+        "extend-shallow": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+            "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+            "dev": true,
+            "requires": {
+                "assign-symbols": "^1.0.0",
+                "is-extendable": "^1.0.1"
+            },
+            "dependencies": {
+                "is-extendable": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+                    "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+                    "dev": true,
+                    "requires": {
+                        "is-plain-object": "^2.0.4"
+                    }
+                }
+            }
+        },
+        "extglob": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+            "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+            "dev": true,
+            "requires": {
+                "is-extglob": "^1.0.0"
+            },
+            "dependencies": {
+                "is-extglob": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+                    "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+                    "dev": true
+                }
+            }
+        },
+        "fast-deep-equal": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+            "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+            "dev": true
+        },
+        "fast-json-stable-stringify": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+            "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+            "dev": true
+        },
+        "fast-levenshtein": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+            "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+            "dev": true
+        },
+        "fast-safe-stringify": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+            "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+            "dev": true
+        },
+        "file-entry-cache": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+            "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+            "dev": true,
+            "requires": {
+                "flat-cache": "^3.0.4"
+            }
+        },
+        "file-uri-to-path": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+            "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+            "dev": true,
+            "optional": true
+        },
+        "filename-regex": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+            "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
+            "dev": true
+        },
+        "filesaver.js-npm": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/filesaver.js-npm/-/filesaver.js-npm-1.0.1.tgz",
+            "integrity": "sha1-rm0dETGU3OT7UKwNkEpA60UVl8c=",
+            "dev": true
+        },
+        "fill-range": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+            "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+            "dev": true,
+            "requires": {
+                "to-regex-range": "^5.0.1"
+            }
+        },
+        "findup-sync": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.3.0.tgz",
+            "integrity": "sha1-N5MKpdgWt3fANEXhlmzGeQpMCxY=",
+            "dev": true,
+            "requires": {
+                "glob": "~5.0.0"
+            },
+            "dependencies": {
+                "glob": {
+                    "version": "5.0.15",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+                    "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+                    "dev": true,
+                    "requires": {
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "2 || 3",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
+                    }
+                }
+            }
+        },
+        "fined": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/fined/-/fined-1.2.0.tgz",
+            "integrity": "sha512-ZYDqPLGxDkDhDZBjZBb+oD1+j0rA4E0pXY50eplAAOPg2N/gUBSSk5IM1/QhPfyVo19lJ+CvXpqfvk+b2p/8Ng==",
+            "dev": true,
+            "requires": {
+                "expand-tilde": "^2.0.2",
+                "is-plain-object": "^2.0.3",
+                "object.defaults": "^1.1.0",
+                "object.pick": "^1.2.0",
+                "parse-filepath": "^1.0.1"
+            }
+        },
+        "flagged-respawn": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-1.0.1.tgz",
+            "integrity": "sha512-lNaHNVymajmk0OJMBn8fVUAU1BtDeKIqKoVhk4xAALB57aALg6b4W0MfJ/cUE0g9YBXy5XhSlPIpYIJ7HaY/3Q==",
+            "dev": true
+        },
+        "flat-cache": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
+            "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
+            "dev": true,
+            "requires": {
+                "flatted": "^3.1.0",
+                "rimraf": "^3.0.2"
+            }
+        },
+        "flatted": {
+            "version": "3.2.5",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.5.tgz",
+            "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==",
+            "dev": true
+        },
+        "for-in": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+            "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+            "dev": true
+        },
+        "for-own": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
+            "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
+            "dev": true,
+            "requires": {
+                "for-in": "^1.0.1"
+            }
+        },
+        "foreach": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+            "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
+            "dev": true
+        },
+        "fragment-cache": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+            "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+            "dev": true,
+            "requires": {
+                "map-cache": "^0.2.2"
+            }
+        },
+        "fs-exists-sync": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
+            "integrity": "sha1-mC1ok6+RjnLQjeyehnP/K1qNat0=",
+            "dev": true
+        },
+        "fs-extra": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-6.0.1.tgz",
+            "integrity": "sha512-GnyIkKhhzXZUWFCaJzvyDLEEgDkPfb4/TPvJCJVuS8MWZgoSsErf++QpiAlDnKFcqhRlm+tIOcencCjyJE6ZCA==",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.1.2",
+                "jsonfile": "^4.0.0",
+                "universalify": "^0.1.0"
+            }
+        },
+        "fs-readdir-recursive": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
+            "integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA==",
+            "dev": true
+        },
+        "fs.realpath": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+            "dev": true
+        },
+        "fsevents": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+            "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+            "dev": true,
+            "optional": true
+        },
+        "function-bind": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+            "dev": true
+        },
+        "functional-red-black-tree": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+            "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+            "dev": true
+        },
+        "gensync": {
+            "version": "1.0.0-beta.2",
+            "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+            "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+            "dev": true
+        },
+        "get-assigned-identifiers": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/get-assigned-identifiers/-/get-assigned-identifiers-1.2.0.tgz",
+            "integrity": "sha512-mBBwmeGTrxEMO4pMaaf/uUEFHnYtwr8FTe8Y/mer4rcV/bye0qGm6pw1bGZFGStxC5O76c5ZAVBGnqHmOaJpdQ==",
+            "dev": true
+        },
+        "get-intrinsic": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+            "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+            "dev": true,
+            "requires": {
+                "function-bind": "^1.1.1",
+                "has": "^1.0.3",
+                "has-symbols": "^1.0.1"
+            }
+        },
+        "get-symbol-description": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
+            "integrity": "sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==",
+            "dev": true,
+            "requires": {
+                "call-bind": "^1.0.2",
+                "get-intrinsic": "^1.1.1"
+            }
+        },
+        "get-value": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+            "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
+            "dev": true
+        },
+        "getobject": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/getobject/-/getobject-1.0.2.tgz",
+            "integrity": "sha512-2zblDBaFcb3rB4rF77XVnuINOE2h2k/OnqXAiy0IrTxUfV1iFp3la33oAQVY9pCpWU268WFYVt2t71hlMuLsOg==",
+            "dev": true
+        },
+        "glob": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+            "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+            "dev": true,
+            "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            }
+        },
+        "glob-base": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+            "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+            "dev": true,
+            "requires": {
+                "glob-parent": "^2.0.0",
+                "is-glob": "^2.0.0"
+            },
+            "dependencies": {
+                "glob-parent": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+                    "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+                    "dev": true,
+                    "requires": {
+                        "is-glob": "^2.0.0"
+                    }
+                },
+                "is-extglob": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+                    "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+                    "dev": true
+                },
+                "is-glob": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+                    "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+                    "dev": true,
+                    "requires": {
+                        "is-extglob": "^1.0.0"
+                    }
+                }
+            }
+        },
+        "glob-parent": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+            "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+            "dev": true,
+            "requires": {
+                "is-glob": "^4.0.1"
+            }
+        },
+        "global-modules": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
+            "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
+            "dev": true,
+            "requires": {
+                "global-prefix": "^1.0.1",
+                "is-windows": "^1.0.1",
+                "resolve-dir": "^1.0.0"
+            }
+        },
+        "global-prefix": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
+            "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
+            "dev": true,
+            "requires": {
+                "expand-tilde": "^2.0.2",
+                "homedir-polyfill": "^1.0.1",
+                "ini": "^1.3.4",
+                "is-windows": "^1.0.1",
+                "which": "^1.2.14"
+            }
+        },
+        "globals": {
+            "version": "11.12.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+            "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+            "dev": true
+        },
+        "google-closure-compiler": {
+            "version": "20180910.1.0",
+            "resolved": "https://registry.npmjs.org/google-closure-compiler/-/google-closure-compiler-20180910.1.0.tgz",
+            "integrity": "sha512-4VdtHL5LoNmMxDgOixiRJmJejvcFCzpC/uX5R4oGquuQG08knb7bgzPQuIBieYjbHETyc03DyksPFR+kjW4LgA==",
+            "dev": true,
+            "requires": {
+                "chalk": "^1.0.0",
+                "google-closure-compiler-linux": "^20180910.0.1",
+                "google-closure-compiler-osx": "^20180910.0.1",
+                "minimist": "^1.2.0",
+                "vinyl": "^2.0.1",
+                "vinyl-sourcemaps-apply": "^0.2.0"
+            }
+        },
+        "google-closure-compiler-linux": {
+            "version": "20180910.0.1",
+            "resolved": "https://registry.npmjs.org/google-closure-compiler-linux/-/google-closure-compiler-linux-20180910.0.1.tgz",
+            "integrity": "sha512-hSTqyLLHDLnntR442BVea0sp49q+Uwi05HMOVBPMmbwDoHLtCpDmwZ/FUKs5GLFZ/cQafk3RgHLktPdReEPMIw==",
+            "dev": true,
+            "optional": true
+        },
+        "google-closure-compiler-osx": {
+            "version": "20180910.0.1",
+            "resolved": "https://registry.npmjs.org/google-closure-compiler-osx/-/google-closure-compiler-osx-20180910.0.1.tgz",
+            "integrity": "sha512-HU2waANIOHBFtAJ205rzF8BGXiJaLT0s6qu4memI7D4ThBhAJLA/SwTlEjrby6OvS+ZRL4e0FYMPJW1/fhQKzg==",
+            "dev": true,
+            "optional": true
+        },
+        "graceful-fs": {
+            "version": "4.2.9",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.9.tgz",
+            "integrity": "sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==",
+            "dev": true
+        },
+        "graceful-readlink": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+            "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
+            "dev": true
+        },
+        "grunt": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/grunt/-/grunt-1.4.1.tgz",
+            "integrity": "sha512-ZXIYXTsAVrA7sM+jZxjQdrBOAg7DyMUplOMhTaspMRExei+fD0BTwdWXnn0W5SXqhb/Q/nlkzXclSi3IH55PIA==",
+            "dev": true,
+            "requires": {
+                "dateformat": "~3.0.3",
+                "eventemitter2": "~0.4.13",
+                "exit": "~0.1.2",
+                "findup-sync": "~0.3.0",
+                "glob": "~7.1.6",
+                "grunt-cli": "~1.4.2",
+                "grunt-known-options": "~2.0.0",
+                "grunt-legacy-log": "~3.0.0",
+                "grunt-legacy-util": "~2.0.1",
+                "iconv-lite": "~0.4.13",
+                "js-yaml": "~3.14.0",
+                "minimatch": "~3.0.4",
+                "mkdirp": "~1.0.4",
+                "nopt": "~3.0.6",
+                "rimraf": "~3.0.2"
+            },
+            "dependencies": {
+                "glob": {
+                    "version": "7.1.7",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+                    "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+                    "dev": true,
+                    "requires": {
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.4",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
+                    }
+                },
+                "grunt-cli": {
+                    "version": "1.4.3",
+                    "resolved": "https://registry.npmjs.org/grunt-cli/-/grunt-cli-1.4.3.tgz",
+                    "integrity": "sha512-9Dtx/AhVeB4LYzsViCjUQkd0Kw0McN2gYpdmGYKtE2a5Yt7v1Q+HYZVWhqXc/kGnxlMtqKDxSwotiGeFmkrCoQ==",
+                    "dev": true,
+                    "requires": {
+                        "grunt-known-options": "~2.0.0",
+                        "interpret": "~1.1.0",
+                        "liftup": "~3.0.1",
+                        "nopt": "~4.0.1",
+                        "v8flags": "~3.2.0"
+                    },
+                    "dependencies": {
+                        "nopt": {
+                            "version": "4.0.3",
+                            "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
+                            "integrity": "sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==",
+                            "dev": true,
+                            "requires": {
+                                "abbrev": "1",
+                                "osenv": "^0.1.4"
+                            }
+                        }
+                    }
+                },
+                "minimatch": {
+                    "version": "3.0.8",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.8.tgz",
+                    "integrity": "sha512-6FsRAQsxQ61mw+qP1ZzbL9Bc78x2p5OqNgNpnoAFLTrX8n5Kxph0CsnhmKKNXTWjXqU5L0pGPR7hYk+XWZr60Q==",
+                    "dev": true,
+                    "requires": {
+                        "brace-expansion": "^1.1.7"
+                    }
+                }
+            }
+        },
+        "grunt-babel": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/grunt-babel/-/grunt-babel-8.0.0.tgz",
+            "integrity": "sha512-WuiZFvGzcyzlEoPIcY1snI234ydDWeWWV5bpnB7PZsOLHcDsxWKnrR1rMWEUsbdVPPjvIirwFNsuo4CbJmsdFQ==",
+            "dev": true
+        },
+        "grunt-browserify": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/grunt-browserify/-/grunt-browserify-6.0.0.tgz",
+            "integrity": "sha512-m130pTVFEsxQZ+dJQd287TrnUI5VvEKJ+MmPjMF/7bVJBTBRWhJlYVFgBOYLZMUykfk1RWXfQ2sAQu5NuXumvg==",
+            "dev": true,
+            "requires": {
+                "async": "^2.5.0",
+                "browserify": "^17.0.0",
+                "browserify-incremental": "^3.1.1",
+                "glob": "^7.1.2",
+                "lodash": "^4.17.4",
+                "resolve": "^1.1.6",
+                "watchify": "^4.0.0"
+            },
+            "dependencies": {
+                "async": {
+                    "version": "2.6.3",
+                    "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+                    "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+                    "dev": true,
+                    "requires": {
+                        "lodash": "^4.17.14"
+                    }
+                },
+                "browserify": {
+                    "version": "17.0.0",
+                    "resolved": "https://registry.npmjs.org/browserify/-/browserify-17.0.0.tgz",
+                    "integrity": "sha512-SaHqzhku9v/j6XsQMRxPyBrSP3gnwmE27gLJYZgMT2GeK3J0+0toN+MnuNYDfHwVGQfLiMZ7KSNSIXHemy905w==",
+                    "dev": true,
+                    "requires": {
+                        "JSONStream": "^1.0.3",
+                        "assert": "^1.4.0",
+                        "browser-pack": "^6.0.1",
+                        "browser-resolve": "^2.0.0",
+                        "browserify-zlib": "~0.2.0",
+                        "buffer": "~5.2.1",
+                        "cached-path-relative": "^1.0.0",
+                        "concat-stream": "^1.6.0",
+                        "console-browserify": "^1.1.0",
+                        "constants-browserify": "~1.0.0",
+                        "crypto-browserify": "^3.0.0",
+                        "defined": "^1.0.0",
+                        "deps-sort": "^2.0.1",
+                        "domain-browser": "^1.2.0",
+                        "duplexer2": "~0.1.2",
+                        "events": "^3.0.0",
+                        "glob": "^7.1.0",
+                        "has": "^1.0.0",
+                        "htmlescape": "^1.1.0",
+                        "https-browserify": "^1.0.0",
+                        "inherits": "~2.0.1",
+                        "insert-module-globals": "^7.2.1",
+                        "labeled-stream-splicer": "^2.0.0",
+                        "mkdirp-classic": "^0.5.2",
+                        "module-deps": "^6.2.3",
+                        "os-browserify": "~0.3.0",
+                        "parents": "^1.0.1",
+                        "path-browserify": "^1.0.0",
+                        "process": "~0.11.0",
+                        "punycode": "^1.3.2",
+                        "querystring-es3": "~0.2.0",
+                        "read-only-stream": "^2.0.0",
+                        "readable-stream": "^2.0.2",
+                        "resolve": "^1.1.4",
+                        "shasum-object": "^1.0.0",
+                        "shell-quote": "^1.6.1",
+                        "stream-browserify": "^3.0.0",
+                        "stream-http": "^3.0.0",
+                        "string_decoder": "^1.1.1",
+                        "subarg": "^1.0.0",
+                        "syntax-error": "^1.1.1",
+                        "through2": "^2.0.0",
+                        "timers-browserify": "^1.0.1",
+                        "tty-browserify": "0.0.1",
+                        "url": "~0.11.0",
+                        "util": "~0.12.0",
+                        "vm-browserify": "^1.0.0",
+                        "xtend": "^4.0.0"
+                    }
+                },
+                "events": {
+                    "version": "3.3.0",
+                    "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+                    "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+                    "dev": true
+                },
+                "path-browserify": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+                    "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+                    "dev": true
+                },
+                "stream-browserify": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-3.0.0.tgz",
+                    "integrity": "sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==",
+                    "dev": true,
+                    "requires": {
+                        "inherits": "~2.0.4",
+                        "readable-stream": "^3.5.0"
+                    },
+                    "dependencies": {
+                        "readable-stream": {
+                            "version": "3.6.0",
+                            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+                            "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+                            "dev": true,
+                            "requires": {
+                                "inherits": "^2.0.3",
+                                "string_decoder": "^1.1.1",
+                                "util-deprecate": "^1.0.1"
+                            }
+                        }
+                    }
+                },
+                "util": {
+                    "version": "0.12.4",
+                    "resolved": "https://registry.npmjs.org/util/-/util-0.12.4.tgz",
+                    "integrity": "sha512-bxZ9qtSlGUWSOy9Qa9Xgk11kSslpuZwaxCg4sNIDj6FLucDab2JxnHwyNTCpHMtK1MjoQiWQ6DiUMZYbSrO+Sw==",
+                    "dev": true,
+                    "requires": {
+                        "inherits": "^2.0.3",
+                        "is-arguments": "^1.0.4",
+                        "is-generator-function": "^1.0.7",
+                        "is-typed-array": "^1.1.3",
+                        "safe-buffer": "^5.1.2",
+                        "which-typed-array": "^1.1.2"
+                    }
+                }
+            }
+        },
+        "grunt-contrib-clean": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/grunt-contrib-clean/-/grunt-contrib-clean-2.0.0.tgz",
+            "integrity": "sha512-g5ZD3ORk6gMa5ugZosLDQl3dZO7cI3R14U75hTM+dVLVxdMNJCPVmwf9OUt4v4eWgpKKWWoVK9DZc1amJp4nQw==",
+            "dev": true,
+            "requires": {
+                "async": "^2.6.1",
+                "rimraf": "^2.6.2"
+            },
+            "dependencies": {
+                "async": {
+                    "version": "2.6.3",
+                    "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+                    "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+                    "dev": true,
+                    "requires": {
+                        "lodash": "^4.17.14"
+                    }
+                },
+                "rimraf": {
+                    "version": "2.7.1",
+                    "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+                    "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+                    "dev": true,
+                    "requires": {
+                        "glob": "^7.1.3"
+                    }
+                }
+            }
+        },
+        "grunt-eslint": {
+            "version": "24.0.0",
+            "resolved": "https://registry.npmjs.org/grunt-eslint/-/grunt-eslint-24.0.0.tgz",
+            "integrity": "sha512-WpTeBBFweyhMuPjGwRSQV9JFJ+EczIdlsc7Dd/1g78QVI1aZsk4g/H3e+3S5HEwsS1RKL2YZIrGj8hMLlBfN8w==",
+            "dev": true,
+            "requires": {
+                "chalk": "^4.1.2",
+                "eslint": "^8.0.1"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "4.3.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "4.1.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+                    "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
+            }
+        },
+        "grunt-exec": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/grunt-exec/-/grunt-exec-3.0.0.tgz",
+            "integrity": "sha512-cgAlreXf3muSYS5LzW0Cc4xHK03BjFOYk0MqCQ/MZ3k1Xz2GU7D+IAJg4UKicxpO+XdONJdx/NJ6kpy2wI+uHg==",
+            "dev": true
+        },
+        "grunt-known-options": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/grunt-known-options/-/grunt-known-options-2.0.0.tgz",
+            "integrity": "sha512-GD7cTz0I4SAede1/+pAbmJRG44zFLPipVtdL9o3vqx9IEyb7b4/Y3s7r6ofI3CchR5GvYJ+8buCSioDv5dQLiA==",
+            "dev": true
+        },
+        "grunt-legacy-log": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-3.0.0.tgz",
+            "integrity": "sha512-GHZQzZmhyq0u3hr7aHW4qUH0xDzwp2YXldLPZTCjlOeGscAOWWPftZG3XioW8MasGp+OBRIu39LFx14SLjXRcA==",
+            "dev": true,
+            "requires": {
+                "colors": "~1.1.2",
+                "grunt-legacy-log-utils": "~2.1.0",
+                "hooker": "~0.2.3",
+                "lodash": "~4.17.19"
+            }
+        },
+        "grunt-legacy-log-utils": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-2.1.0.tgz",
+            "integrity": "sha512-lwquaPXJtKQk0rUM1IQAop5noEpwFqOXasVoedLeNzaibf/OPWjKYvvdqnEHNmU+0T0CaReAXIbGo747ZD+Aaw==",
+            "dev": true,
+            "requires": {
+                "chalk": "~4.1.0",
+                "lodash": "~4.17.19"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "4.3.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "4.1.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+                    "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
+            }
+        },
+        "grunt-legacy-util": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-2.0.1.tgz",
+            "integrity": "sha512-2bQiD4fzXqX8rhNdXkAywCadeqiPiay0oQny77wA2F3WF4grPJXCvAcyoWUJV+po/b15glGkxuSiQCK299UC2w==",
+            "dev": true,
+            "requires": {
+                "async": "~3.2.0",
+                "exit": "~0.1.2",
+                "getobject": "~1.0.0",
+                "hooker": "~0.2.3",
+                "lodash": "~4.17.21",
+                "underscore.string": "~3.3.5",
+                "which": "~2.0.2"
+            },
+            "dependencies": {
+                "which": {
+                    "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+                    "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+                    "dev": true,
+                    "requires": {
+                        "isexe": "^2.0.0"
+                    }
+                }
+            }
+        },
+        "grunt-npmcopy": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/grunt-npmcopy/-/grunt-npmcopy-0.2.0.tgz",
+            "integrity": "sha512-iiIpifpz5UCWPYtskdgCbDjKOoSjmwdEj9hvIHZFHVWjjfehXN6VNoeBp9c6v8XuD81BnRLRf8z/rkwmmmxvqA==",
+            "dev": true,
+            "requires": {
+                "glob": "^7.1.3",
+                "lodash": "^4.17.11"
+            }
+        },
+        "grunt-sync": {
+            "version": "0.8.2",
+            "resolved": "https://registry.npmjs.org/grunt-sync/-/grunt-sync-0.8.2.tgz",
+            "integrity": "sha512-PB+xKI9YPyZn3NZQXpKHfZVlxHdf1L8GMl+Wi0mLhYypWuOdZPW2EzTmSuhhFbXjkb0aIOxvII1zdZZEl9zqGg==",
+            "dev": true,
+            "requires": {
+                "fs-extra": "^6.0.1",
+                "glob": "^7.0.5",
+                "md5-file": "^2.0.3"
+            }
+        },
+        "has": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+            "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+            "dev": true,
+            "requires": {
+                "function-bind": "^1.1.1"
+            }
+        },
+        "has-ansi": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+            "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+            "dev": true,
+            "requires": {
+                "ansi-regex": "^2.0.0"
+            }
+        },
+        "has-bigints": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
+            "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==",
+            "dev": true
+        },
+        "has-flag": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+            "dev": true
+        },
+        "has-symbols": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+            "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+            "dev": true
+        },
+        "has-tostringtag": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
+            "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+            "dev": true,
+            "requires": {
+                "has-symbols": "^1.0.2"
+            }
+        },
+        "has-value": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+            "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+            "dev": true,
+            "requires": {
+                "get-value": "^2.0.6",
+                "has-values": "^1.0.0",
+                "isobject": "^3.0.0"
+            }
+        },
+        "has-values": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+            "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+            "dev": true,
+            "requires": {
+                "is-number": "^3.0.0",
+                "kind-of": "^4.0.0"
+            },
+            "dependencies": {
+                "is-number": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+                    "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^3.0.2"
+                    },
+                    "dependencies": {
+                        "kind-of": {
+                            "version": "3.2.2",
+                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                            "dev": true,
+                            "requires": {
+                                "is-buffer": "^1.1.5"
+                            }
+                        }
+                    }
+                },
+                "kind-of": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+                    "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "^1.1.5"
+                    }
+                }
+            }
+        },
+        "hash-base": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
+            "integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
+            "dev": true,
+            "requires": {
+                "inherits": "^2.0.4",
+                "readable-stream": "^3.6.0",
+                "safe-buffer": "^5.2.0"
+            },
+            "dependencies": {
+                "readable-stream": {
+                    "version": "3.6.0",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+                    "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+                    "dev": true,
+                    "requires": {
+                        "inherits": "^2.0.3",
+                        "string_decoder": "^1.1.1",
+                        "util-deprecate": "^1.0.1"
+                    }
+                }
+            }
+        },
+        "hash.js": {
+            "version": "1.1.7",
+            "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+            "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+            "dev": true,
+            "requires": {
+                "inherits": "^2.0.3",
+                "minimalistic-assert": "^1.0.1"
+            }
+        },
+        "hmac-drbg": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+            "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
+            "dev": true,
+            "requires": {
+                "hash.js": "^1.0.3",
+                "minimalistic-assert": "^1.0.0",
+                "minimalistic-crypto-utils": "^1.0.1"
+            }
+        },
+        "homedir-polyfill": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
+            "integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
+            "dev": true,
+            "requires": {
+                "parse-passwd": "^1.0.0"
+            }
+        },
+        "hooker": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
+            "integrity": "sha1-uDT3I8xKJCqmWWNFnfbZhMXT2Vk=",
+            "dev": true
+        },
+        "htmlescape": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/htmlescape/-/htmlescape-1.1.1.tgz",
+            "integrity": "sha1-OgPtwiFLyjtmQko+eVk0lQnLA1E=",
+            "dev": true
+        },
+        "https-browserify": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
+            "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
+            "dev": true
+        },
+        "iconv-lite": {
+            "version": "0.4.24",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+            "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+            "dev": true,
+            "requires": {
+                "safer-buffer": ">= 2.1.2 < 3"
+            }
+        },
+        "ieee754": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+            "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+            "dev": true
+        },
+        "ignore": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+            "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+            "dev": true
+        },
+        "immediate": {
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+            "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=",
+            "dev": true
+        },
+        "import-fresh": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+            "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+            "dev": true,
+            "requires": {
+                "parent-module": "^1.0.0",
+                "resolve-from": "^4.0.0"
+            }
+        },
+        "imurmurhash": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+            "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+            "dev": true
+        },
+        "inflight": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+            "dev": true,
+            "requires": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+            }
+        },
+        "inherits": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+            "dev": true
+        },
+        "ini": {
+            "version": "1.3.8",
+            "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+            "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+            "dev": true
+        },
+        "inline-source-map": {
+            "version": "0.6.2",
+            "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.6.2.tgz",
+            "integrity": "sha1-+Tk0ccGKedFyT4Y/o4tYY3Ct4qU=",
+            "dev": true,
+            "requires": {
+                "source-map": "~0.5.3"
+            }
+        },
+        "insert-module-globals": {
+            "version": "7.2.1",
+            "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-7.2.1.tgz",
+            "integrity": "sha512-ufS5Qq9RZN+Bu899eA9QCAYThY+gGW7oRkmb0vC93Vlyu/CFGcH0OYPEjVkDXA5FEbTt1+VWzdoOD3Ny9N+8tg==",
+            "dev": true,
+            "requires": {
+                "JSONStream": "^1.0.3",
+                "acorn-node": "^1.5.2",
+                "combine-source-map": "^0.8.0",
+                "concat-stream": "^1.6.1",
+                "is-buffer": "^1.1.0",
+                "path-is-absolute": "^1.0.1",
+                "process": "~0.11.0",
+                "through2": "^2.0.0",
+                "undeclared-identifiers": "^1.1.2",
+                "xtend": "^4.0.0"
+            }
+        },
+        "internal-slot": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
+            "integrity": "sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==",
+            "dev": true,
+            "requires": {
+                "get-intrinsic": "^1.1.0",
+                "has": "^1.0.3",
+                "side-channel": "^1.0.4"
+            }
+        },
+        "interpret": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
+            "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=",
+            "dev": true
+        },
+        "invariant": {
+            "version": "2.2.4",
+            "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+            "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+            "dev": true,
+            "requires": {
+                "loose-envify": "^1.0.0"
+            }
+        },
+        "is-absolute": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
+            "integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
+            "dev": true,
+            "requires": {
+                "is-relative": "^1.0.0",
+                "is-windows": "^1.0.1"
+            }
+        },
+        "is-accessor-descriptor": {
+            "version": "0.1.6",
+            "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+            "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+            "dev": true,
+            "requires": {
+                "kind-of": "^3.0.2"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "^1.1.5"
+                    }
+                }
+            }
+        },
+        "is-arguments": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
+            "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
+            "dev": true,
+            "requires": {
+                "call-bind": "^1.0.2",
+                "has-tostringtag": "^1.0.0"
+            }
+        },
+        "is-bigint": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
+            "integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
+            "dev": true,
+            "requires": {
+                "has-bigints": "^1.0.1"
+            }
+        },
+        "is-binary-path": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+            "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+            "dev": true,
+            "requires": {
+                "binary-extensions": "^2.0.0"
+            }
+        },
+        "is-boolean-object": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
+            "integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
+            "dev": true,
+            "requires": {
+                "call-bind": "^1.0.2",
+                "has-tostringtag": "^1.0.0"
+            }
+        },
+        "is-buffer": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+            "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+            "dev": true
+        },
+        "is-callable": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
+            "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
+            "dev": true
+        },
+        "is-core-module": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
+            "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
+            "dev": true,
+            "requires": {
+                "has": "^1.0.3"
+            }
+        },
+        "is-data-descriptor": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+            "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+            "dev": true,
+            "requires": {
+                "kind-of": "^3.0.2"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "^1.1.5"
+                    }
+                }
+            }
+        },
+        "is-date-object": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
+            "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
+            "dev": true,
+            "requires": {
+                "has-tostringtag": "^1.0.0"
+            }
+        },
+        "is-descriptor": {
+            "version": "0.1.6",
+            "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+            "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+            "dev": true,
+            "requires": {
+                "is-accessor-descriptor": "^0.1.6",
+                "is-data-descriptor": "^0.1.4",
+                "kind-of": "^5.0.0"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+                    "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+                    "dev": true
+                }
+            }
+        },
+        "is-dotfile": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+            "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
+            "dev": true
+        },
+        "is-equal-shallow": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+            "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+            "dev": true,
+            "requires": {
+                "is-primitive": "^2.0.0"
+            }
+        },
+        "is-extendable": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+            "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+            "dev": true
+        },
+        "is-extglob": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+            "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+            "dev": true
+        },
+        "is-generator-function": {
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
+            "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
+            "dev": true,
+            "requires": {
+                "has-tostringtag": "^1.0.0"
+            }
+        },
+        "is-glob": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+            "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+            "dev": true,
+            "requires": {
+                "is-extglob": "^2.1.1"
+            }
+        },
+        "is-negative-zero": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
+            "integrity": "sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==",
+            "dev": true
+        },
+        "is-number": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+            "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+            "dev": true
+        },
+        "is-number-object": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.6.tgz",
+            "integrity": "sha512-bEVOqiRcvo3zO1+G2lVMy+gkkEm9Yh7cDMRusKKu5ZJKPUYSJwICTKZrNKHA2EbSP0Tu0+6B/emsYNHZyn6K8g==",
+            "dev": true,
+            "requires": {
+                "has-tostringtag": "^1.0.0"
+            }
+        },
+        "is-plain-object": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+            "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+            "dev": true,
+            "requires": {
+                "isobject": "^3.0.1"
+            }
+        },
+        "is-posix-bracket": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+            "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
+            "dev": true
+        },
+        "is-primitive": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+            "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
+            "dev": true
+        },
+        "is-regex": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
+            "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+            "dev": true,
+            "requires": {
+                "call-bind": "^1.0.2",
+                "has-tostringtag": "^1.0.0"
+            }
+        },
+        "is-relative": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
+            "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
+            "dev": true,
+            "requires": {
+                "is-unc-path": "^1.0.0"
+            }
+        },
+        "is-shared-array-buffer": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.1.tgz",
+            "integrity": "sha512-IU0NmyknYZN0rChcKhRO1X8LYz5Isj/Fsqh8NJOSf+N/hCOTwy29F32Ik7a+QszE63IdvmwdTPDd6cZ5pg4cwA==",
+            "dev": true
+        },
+        "is-string": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
+            "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+            "dev": true,
+            "requires": {
+                "has-tostringtag": "^1.0.0"
+            }
+        },
+        "is-symbol": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
+            "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
+            "dev": true,
+            "requires": {
+                "has-symbols": "^1.0.2"
+            }
+        },
+        "is-typed-array": {
+            "version": "1.1.8",
+            "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.8.tgz",
+            "integrity": "sha512-HqH41TNZq2fgtGT8WHVFVJhBVGuY3AnP3Q36K8JKXUxSxRgk/d+7NjmwG2vo2mYmXK8UYZKu0qH8bVP5gEisjA==",
+            "dev": true,
+            "requires": {
+                "available-typed-arrays": "^1.0.5",
+                "call-bind": "^1.0.2",
+                "es-abstract": "^1.18.5",
+                "foreach": "^2.0.5",
+                "has-tostringtag": "^1.0.0"
+            }
+        },
+        "is-unc-path": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-1.0.0.tgz",
+            "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
+            "dev": true,
+            "requires": {
+                "unc-path-regex": "^0.1.2"
+            }
+        },
+        "is-weakref": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
+            "integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
+            "dev": true,
+            "requires": {
+                "call-bind": "^1.0.2"
+            }
+        },
+        "is-windows": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+            "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+            "dev": true
+        },
+        "isarray": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+            "dev": true
+        },
+        "isexe": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+            "dev": true
+        },
+        "isobject": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+            "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+            "dev": true
+        },
+        "js-reporters": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/js-reporters/-/js-reporters-1.2.0.tgz",
+            "integrity": "sha1-fPLLaYGWaEeQNQ0MTKB/Su2ewX4=",
+            "dev": true
+        },
+        "js-tokens": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+            "dev": true
+        },
+        "js-yaml": {
+            "version": "3.14.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+            "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+            "dev": true,
+            "requires": {
+                "argparse": "^1.0.7",
+                "esprima": "^4.0.0"
+            }
+        },
+        "jsesc": {
+            "version": "2.5.2",
+            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+            "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+            "dev": true
+        },
+        "json-schema-traverse": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+            "dev": true
+        },
+        "json-stable-stringify": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz",
+            "integrity": "sha1-YRwj6BTbN1Un34URk9tZ3Sryf0U=",
+            "dev": true,
+            "requires": {
+                "jsonify": "~0.0.0"
+            }
+        },
+        "json-stable-stringify-without-jsonify": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+            "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+            "dev": true
+        },
+        "json5": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
+            "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
+            "dev": true,
+            "requires": {
+                "minimist": "^1.2.5"
+            }
+        },
+        "jsonfile": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+            "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.1.6"
+            }
+        },
+        "jsonify": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+            "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+            "dev": true
+        },
+        "jsonparse": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+            "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
+            "dev": true
+        },
+        "jszip": {
+            "version": "3.7.1",
+            "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.7.1.tgz",
+            "integrity": "sha512-ghL0tz1XG9ZEmRMcEN2vt7xabrDdqHHeykgARpmZ0BiIctWxM47Vt63ZO2dnp4QYt/xJVLLy5Zv1l/xRdh2byg==",
+            "dev": true,
+            "requires": {
+                "lie": "~3.3.0",
+                "pako": "~1.0.2",
+                "readable-stream": "~2.3.6",
+                "set-immediate-shim": "~1.0.1"
+            }
+        },
+        "kind-of": {
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+            "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+            "dev": true
+        },
+        "labeled-stream-splicer": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-2.0.2.tgz",
+            "integrity": "sha512-Ca4LSXFFZUjPScRaqOcFxneA0VpKZr4MMYCljyQr4LIewTLb3Y0IUTIsnBBsVubIeEfxeSZpSjSsRM8APEQaAw==",
+            "dev": true,
+            "requires": {
+                "inherits": "^2.0.1",
+                "stream-splicer": "^2.0.0"
+            }
+        },
+        "levn": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+            "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+            "dev": true,
+            "requires": {
+                "prelude-ls": "^1.2.1",
+                "type-check": "~0.4.0"
+            }
+        },
+        "lie": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+            "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+            "dev": true,
+            "requires": {
+                "immediate": "~3.0.5"
+            }
+        },
+        "liftup": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/liftup/-/liftup-3.0.1.tgz",
+            "integrity": "sha512-yRHaiQDizWSzoXk3APcA71eOI/UuhEkNN9DiW2Tt44mhYzX4joFoCZlxsSOF7RyeLlfqzFLQI1ngFq3ggMPhOw==",
+            "dev": true,
+            "requires": {
+                "extend": "^3.0.2",
+                "findup-sync": "^4.0.0",
+                "fined": "^1.2.0",
+                "flagged-respawn": "^1.0.1",
+                "is-plain-object": "^2.0.4",
+                "object.map": "^1.0.1",
+                "rechoir": "^0.7.0",
+                "resolve": "^1.19.0"
+            },
+            "dependencies": {
+                "findup-sync": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-4.0.0.tgz",
+                    "integrity": "sha512-6jvvn/12IC4quLBL1KNokxC7wWTvYncaVUYSoxWw7YykPLuRrnv4qdHcSOywOI5RpkOVGeQRtWM8/q+G6W6qfQ==",
+                    "dev": true,
+                    "requires": {
+                        "detect-file": "^1.0.0",
+                        "is-glob": "^4.0.0",
+                        "micromatch": "^4.0.2",
+                        "resolve-dir": "^1.0.1"
+                    }
+                }
+            }
+        },
+        "lodash": {
+            "version": "4.17.21",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+            "dev": true
+        },
+        "lodash.debounce": {
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+            "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
+            "dev": true
+        },
+        "lodash.memoize": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz",
+            "integrity": "sha1-LcvSwofLwKVcxCMovQxzYVDVPj8=",
+            "dev": true
+        },
+        "lodash.merge": {
+            "version": "4.6.2",
+            "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+            "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+            "dev": true
+        },
+        "loose-envify": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+            "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+            "dev": true,
+            "requires": {
+                "js-tokens": "^3.0.0 || ^4.0.0"
+            }
+        },
+        "make-dir": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+            "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+            "dev": true,
+            "requires": {
+                "pify": "^4.0.1",
+                "semver": "^5.6.0"
+            }
+        },
+        "make-iterator": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/make-iterator/-/make-iterator-1.0.1.tgz",
+            "integrity": "sha512-pxiuXh0iVEq7VM7KMIhs5gxsfxCux2URptUQaXo4iZZJxBAzTPOLE2BumO5dbfVYq/hBJFBR/a1mFDmOx5AGmw==",
+            "dev": true,
+            "requires": {
+                "kind-of": "^6.0.2"
+            }
+        },
+        "map-cache": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+            "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+            "dev": true
+        },
+        "map-visit": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+            "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+            "dev": true,
+            "requires": {
+                "object-visit": "^1.0.0"
+            }
+        },
+        "matcher-collection": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.1.2.tgz",
+            "integrity": "sha512-YQ/teqaOIIfUHedRam08PB3NK7Mjct6BvzRnJmpGDm8uFXpNr1sbY4yuflI5JcEs6COpYA0FpRQhSDBf1tT95g==",
+            "dev": true,
+            "requires": {
+                "minimatch": "^3.0.2"
+            }
+        },
+        "math-random": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.4.tgz",
+            "integrity": "sha512-rUxjysqif/BZQH2yhd5Aaq7vXMSx9NdEsQcyA07uEzIvxgI7zIr33gGsh+RU0/XjmQpCW7RsVof1vlkvQVCK5A==",
+            "dev": true
+        },
+        "md5-file": {
+            "version": "2.0.7",
+            "resolved": "https://registry.npmjs.org/md5-file/-/md5-file-2.0.7.tgz",
+            "integrity": "sha1-MH94vQTMsFTkZ+xmHPpamv3J8hA=",
+            "dev": true
+        },
+        "md5.js": {
+            "version": "1.3.5",
+            "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
+            "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+            "dev": true,
+            "requires": {
+                "hash-base": "^3.0.0",
+                "inherits": "^2.0.1",
+                "safe-buffer": "^5.1.2"
+            }
+        },
+        "micromatch": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
+            "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+            "dev": true,
+            "requires": {
+                "braces": "^3.0.1",
+                "picomatch": "^2.2.3"
+            }
+        },
+        "miller-rabin": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
+            "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
+            "dev": true,
+            "requires": {
+                "bn.js": "^4.0.0",
+                "brorand": "^1.0.1"
+            },
+            "dependencies": {
+                "bn.js": {
+                    "version": "4.12.0",
+                    "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+                    "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+                    "dev": true
+                }
+            }
+        },
+        "minimalistic-assert": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+            "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+            "dev": true
+        },
+        "minimalistic-crypto-utils": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+            "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
+            "dev": true
+        },
+        "minimatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "dev": true,
+            "requires": {
+                "brace-expansion": "^1.1.7"
+            }
+        },
+        "minimist": {
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+            "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+            "dev": true
+        },
+        "mixin-deep": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
+            "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
+            "dev": true,
+            "requires": {
+                "for-in": "^1.0.2",
+                "is-extendable": "^1.0.1"
+            },
+            "dependencies": {
+                "is-extendable": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+                    "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+                    "dev": true,
+                    "requires": {
+                        "is-plain-object": "^2.0.4"
+                    }
+                }
+            }
+        },
+        "mkdirp": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+            "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+            "dev": true
+        },
+        "mkdirp-classic": {
+            "version": "0.5.3",
+            "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+            "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+            "dev": true
+        },
+        "module-deps": {
+            "version": "6.2.3",
+            "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-6.2.3.tgz",
+            "integrity": "sha512-fg7OZaQBcL4/L+AK5f4iVqf9OMbCclXfy/znXRxTVhJSeW5AIlS9AwheYwDaXM3lVW7OBeaeUEY3gbaC6cLlSA==",
+            "dev": true,
+            "requires": {
+                "JSONStream": "^1.0.3",
+                "browser-resolve": "^2.0.0",
+                "cached-path-relative": "^1.0.2",
+                "concat-stream": "~1.6.0",
+                "defined": "^1.0.0",
+                "detective": "^5.2.0",
+                "duplexer2": "^0.1.2",
+                "inherits": "^2.0.1",
+                "parents": "^1.0.0",
+                "readable-stream": "^2.0.2",
+                "resolve": "^1.4.0",
+                "stream-combiner2": "^1.1.1",
+                "subarg": "^1.0.0",
+                "through2": "^2.0.0",
+                "xtend": "^4.0.0"
+            }
+        },
+        "ms": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+            "dev": true
+        },
+        "nan": {
+            "version": "2.15.0",
+            "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
+            "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==",
+            "dev": true,
+            "optional": true
+        },
+        "nanomatch": {
+            "version": "1.2.13",
+            "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
+            "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
+            "dev": true,
+            "requires": {
+                "arr-diff": "^4.0.0",
+                "array-unique": "^0.3.2",
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "fragment-cache": "^0.2.1",
+                "is-windows": "^1.0.2",
+                "kind-of": "^6.0.2",
+                "object.pick": "^1.3.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
+            },
+            "dependencies": {
+                "arr-diff": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+                    "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+                    "dev": true
+                },
+                "array-unique": {
+                    "version": "0.3.2",
+                    "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+                    "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+                    "dev": true
+                }
+            }
+        },
+        "natural-compare": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+            "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+            "dev": true
+        },
+        "node-releases": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.2.tgz",
+            "integrity": "sha512-XxYDdcQ6eKqp/YjI+tb2C5WM2LgjnZrfYg4vgQt49EK268b6gYCHsBLrK2qvJo4FmCtqmKezb0WZFK4fkrZNsg==",
+            "dev": true
+        },
+        "nopt": {
+            "version": "3.0.6",
+            "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+            "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+            "dev": true,
+            "requires": {
+                "abbrev": "1"
+            }
+        },
+        "normalize-path": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+            "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+            "dev": true
+        },
+        "object-assign": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+            "dev": true
+        },
+        "object-copy": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+            "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+            "dev": true,
+            "requires": {
+                "copy-descriptor": "^0.1.0",
+                "define-property": "^0.2.5",
+                "kind-of": "^3.0.3"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "0.2.5",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+                    "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                    "dev": true,
+                    "requires": {
+                        "is-descriptor": "^0.1.0"
+                    }
+                },
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "^1.1.5"
+                    }
+                }
+            }
+        },
+        "object-inspect": {
+            "version": "1.12.0",
+            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
+            "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==",
+            "dev": true
+        },
+        "object-keys": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+            "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+            "dev": true
+        },
+        "object-visit": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+            "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+            "dev": true,
+            "requires": {
+                "isobject": "^3.0.0"
+            }
+        },
+        "object.assign": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+            "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+            "dev": true,
+            "requires": {
+                "call-bind": "^1.0.0",
+                "define-properties": "^1.1.3",
+                "has-symbols": "^1.0.1",
+                "object-keys": "^1.1.1"
+            }
+        },
+        "object.defaults": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/object.defaults/-/object.defaults-1.1.0.tgz",
+            "integrity": "sha1-On+GgzS0B96gbaFtiNXNKeQ1/s8=",
+            "dev": true,
+            "requires": {
+                "array-each": "^1.0.1",
+                "array-slice": "^1.0.0",
+                "for-own": "^1.0.0",
+                "isobject": "^3.0.0"
+            }
+        },
+        "object.map": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/object.map/-/object.map-1.0.1.tgz",
+            "integrity": "sha1-z4Plncj8wK1fQlDh94s7gb2AHTc=",
+            "dev": true,
+            "requires": {
+                "for-own": "^1.0.0",
+                "make-iterator": "^1.0.0"
+            }
+        },
+        "object.omit": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+            "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+            "dev": true,
+            "requires": {
+                "for-own": "^0.1.4",
+                "is-extendable": "^0.1.1"
+            },
+            "dependencies": {
+                "for-own": {
+                    "version": "0.1.5",
+                    "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+                    "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+                    "dev": true,
+                    "requires": {
+                        "for-in": "^1.0.1"
+                    }
+                }
+            }
+        },
+        "object.pick": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+            "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+            "dev": true,
+            "requires": {
+                "isobject": "^3.0.1"
+            }
+        },
+        "once": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+            "dev": true,
+            "requires": {
+                "wrappy": "1"
+            }
+        },
+        "optionator": {
+            "version": "0.9.1",
+            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
+            "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+            "dev": true,
+            "requires": {
+                "deep-is": "^0.1.3",
+                "fast-levenshtein": "^2.0.6",
+                "levn": "^0.4.1",
+                "prelude-ls": "^1.2.1",
+                "type-check": "^0.4.0",
+                "word-wrap": "^1.2.3"
+            }
+        },
+        "os-browserify": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
+            "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc=",
+            "dev": true
+        },
+        "os-homedir": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+            "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+            "dev": true
+        },
+        "os-tmpdir": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+            "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+            "dev": true
+        },
+        "osenv": {
+            "version": "0.1.5",
+            "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+            "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+            "dev": true,
+            "requires": {
+                "os-homedir": "^1.0.0",
+                "os-tmpdir": "^1.0.0"
+            }
+        },
+        "outpipe": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/outpipe/-/outpipe-1.1.1.tgz",
+            "integrity": "sha1-UM+GFjZeh+Ax4ppeyTOaPaRyX6I=",
+            "dev": true,
+            "requires": {
+                "shell-quote": "^1.4.2"
+            }
+        },
+        "pako": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+            "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+            "dev": true
+        },
+        "parent-module": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+            "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+            "dev": true,
+            "requires": {
+                "callsites": "^3.0.0"
+            }
+        },
+        "parents": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz",
+            "integrity": "sha1-/t1NK/GTp3dF/nHjcdc8MwfZx1E=",
+            "dev": true,
+            "requires": {
+                "path-platform": "~0.11.15"
+            }
+        },
+        "parse-asn1": {
+            "version": "5.1.6",
+            "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.6.tgz",
+            "integrity": "sha512-RnZRo1EPU6JBnra2vGHj0yhp6ebyjBZpmUCLHWiFhxlzvBCCpAuZ7elsBp1PVAbQN0/04VD/19rfzlBSwLstMw==",
+            "dev": true,
+            "requires": {
+                "asn1.js": "^5.2.0",
+                "browserify-aes": "^1.0.0",
+                "evp_bytestokey": "^1.0.0",
+                "pbkdf2": "^3.0.3",
+                "safe-buffer": "^5.1.1"
+            }
+        },
+        "parse-filepath": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.2.tgz",
+            "integrity": "sha1-pjISf1Oq89FYdvWHLz/6x2PWyJE=",
+            "dev": true,
+            "requires": {
+                "is-absolute": "^1.0.0",
+                "map-cache": "^0.2.0",
+                "path-root": "^0.1.1"
+            }
+        },
+        "parse-glob": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+            "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+            "dev": true,
+            "requires": {
+                "glob-base": "^0.3.0",
+                "is-dotfile": "^1.0.0",
+                "is-extglob": "^1.0.0",
+                "is-glob": "^2.0.0"
+            },
+            "dependencies": {
+                "is-extglob": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+                    "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+                    "dev": true
+                },
+                "is-glob": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+                    "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+                    "dev": true,
+                    "requires": {
+                        "is-extglob": "^1.0.0"
+                    }
+                }
+            }
+        },
+        "parse-passwd": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
+            "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
+            "dev": true
+        },
+        "pascalcase": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+            "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
+            "dev": true
+        },
+        "path-browserify": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.1.tgz",
+            "integrity": "sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ==",
+            "dev": true
+        },
+        "path-is-absolute": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+            "dev": true
+        },
+        "path-key": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+            "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+            "dev": true
+        },
+        "path-parse": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+            "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+            "dev": true
+        },
+        "path-platform": {
+            "version": "0.11.15",
+            "resolved": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz",
+            "integrity": "sha1-6GQhf3TDaFDwhSt43Hv31KVyG/I=",
+            "dev": true
+        },
+        "path-root": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
+            "integrity": "sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc=",
+            "dev": true,
+            "requires": {
+                "path-root-regex": "^0.1.0"
+            }
+        },
+        "path-root-regex": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/path-root-regex/-/path-root-regex-0.1.2.tgz",
+            "integrity": "sha1-v8zcjfWxLcUsi0PsONGNcsBLqW0=",
+            "dev": true
+        },
+        "pbkdf2": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.2.tgz",
+            "integrity": "sha512-iuh7L6jA7JEGu2WxDwtQP1ddOpaJNC4KlDEFfdQajSGgGPNi4OyDc2R7QnbY2bR9QjBVGwgvTdNJZoE7RaxUMA==",
+            "dev": true,
+            "requires": {
+                "create-hash": "^1.1.2",
+                "create-hmac": "^1.1.4",
+                "ripemd160": "^2.0.1",
+                "safe-buffer": "^5.0.1",
+                "sha.js": "^2.4.8"
+            }
+        },
+        "picocolors": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+            "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+            "dev": true
+        },
+        "picomatch": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+            "dev": true
+        },
+        "pify": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+            "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+            "dev": true
+        },
+        "posix-character-classes": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+            "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
+            "dev": true
+        },
+        "prelude-ls": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+            "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+            "dev": true
+        },
+        "preserve": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+            "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
+            "dev": true
+        },
+        "private": {
+            "version": "0.1.8",
+            "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
+            "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
+            "dev": true
+        },
+        "process": {
+            "version": "0.11.10",
+            "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+            "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
+            "dev": true
+        },
+        "process-nextick-args": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+            "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+            "dev": true
+        },
+        "public-encrypt": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
+            "integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
+            "dev": true,
+            "requires": {
+                "bn.js": "^4.1.0",
+                "browserify-rsa": "^4.0.0",
+                "create-hash": "^1.1.0",
+                "parse-asn1": "^5.0.0",
+                "randombytes": "^2.0.1",
+                "safe-buffer": "^5.1.2"
+            },
+            "dependencies": {
+                "bn.js": {
+                    "version": "4.12.0",
+                    "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+                    "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+                    "dev": true
+                }
+            }
+        },
+        "punycode": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+            "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+            "dev": true
+        },
+        "querystring": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+            "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+            "dev": true
+        },
+        "querystring-es3": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
+            "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
+            "dev": true
+        },
+        "qunit-assert-close": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/qunit-assert-close/-/qunit-assert-close-2.1.2.tgz",
+            "integrity": "sha1-cC1pSSr1kBCi5AQN1k/gzS4EPuE=",
+            "dev": true
+        },
+        "qunitjs": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/qunitjs/-/qunitjs-2.4.1.tgz",
+            "integrity": "sha512-by/2zYvsNdS6Q6Ev6UJ3qJK+OYVlTzWlQ4afaeYMhVh1dd2K3N1ZZKCrCm3WSWPnz5ELMT8WyJRcVy5PXT2y+Q==",
+            "dev": true,
+            "requires": {
+                "chokidar": "1.6.1",
+                "commander": "2.9.0",
+                "exists-stat": "1.0.0",
+                "findup-sync": "0.4.3",
+                "js-reporters": "1.2.0",
+                "resolve": "1.3.2",
+                "walk-sync": "0.3.1"
+            },
+            "dependencies": {
+                "anymatch": {
+                    "version": "1.3.2",
+                    "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
+                    "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
+                    "dev": true,
+                    "requires": {
+                        "micromatch": "^2.1.5",
+                        "normalize-path": "^2.0.0"
+                    }
+                },
+                "binary-extensions": {
+                    "version": "1.13.1",
+                    "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
+                    "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
+                    "dev": true
+                },
+                "braces": {
+                    "version": "1.8.5",
+                    "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+                    "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+                    "dev": true,
+                    "requires": {
+                        "expand-range": "^1.8.1",
+                        "preserve": "^0.2.0",
+                        "repeat-element": "^1.1.2"
+                    }
+                },
+                "chokidar": {
+                    "version": "1.6.1",
+                    "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.6.1.tgz",
+                    "integrity": "sha1-L0RHq16W5Q+z14n9kNTHLg5McMI=",
+                    "dev": true,
+                    "requires": {
+                        "anymatch": "^1.3.0",
+                        "async-each": "^1.0.0",
+                        "fsevents": "^1.0.0",
+                        "glob-parent": "^2.0.0",
+                        "inherits": "^2.0.1",
+                        "is-binary-path": "^1.0.0",
+                        "is-glob": "^2.0.0",
+                        "path-is-absolute": "^1.0.0",
+                        "readdirp": "^2.0.0"
+                    }
+                },
+                "detect-file": {
+                    "version": "0.1.0",
+                    "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-0.1.0.tgz",
+                    "integrity": "sha1-STXe39lIhkjgBrASlWbpOGcR6mM=",
+                    "dev": true,
+                    "requires": {
+                        "fs-exists-sync": "^0.1.0"
+                    }
+                },
+                "expand-tilde": {
+                    "version": "1.2.2",
+                    "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
+                    "integrity": "sha1-C4HrqJflo9MdHD0QL48BRB5VlEk=",
+                    "dev": true,
+                    "requires": {
+                        "os-homedir": "^1.0.1"
+                    }
+                },
+                "fill-range": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+                    "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+                    "dev": true,
+                    "requires": {
+                        "extend-shallow": "^2.0.1",
+                        "is-number": "^3.0.0",
+                        "repeat-string": "^1.6.1",
+                        "to-regex-range": "^2.1.0"
+                    },
+                    "dependencies": {
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "dev": true,
+                            "requires": {
+                                "is-extendable": "^0.1.0"
+                            }
+                        }
+                    }
+                },
+                "findup-sync": {
+                    "version": "0.4.3",
+                    "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.4.3.tgz",
+                    "integrity": "sha1-QAQ5Kee8YK3wt/SCfExudaDeyhI=",
+                    "dev": true,
+                    "requires": {
+                        "detect-file": "^0.1.0",
+                        "is-glob": "^2.0.1",
+                        "micromatch": "^2.3.7",
+                        "resolve-dir": "^0.1.0"
+                    }
+                },
+                "fsevents": {
+                    "version": "1.2.13",
+                    "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
+                    "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "bindings": "^1.5.0",
+                        "nan": "^2.12.1"
+                    }
+                },
+                "glob-parent": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+                    "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+                    "dev": true,
+                    "requires": {
+                        "is-glob": "^2.0.0"
+                    }
+                },
+                "global-modules": {
+                    "version": "0.2.3",
+                    "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz",
+                    "integrity": "sha1-6lo77ULG1s6ZWk+KEmm12uIjgo0=",
+                    "dev": true,
+                    "requires": {
+                        "global-prefix": "^0.1.4",
+                        "is-windows": "^0.2.0"
+                    }
+                },
+                "global-prefix": {
+                    "version": "0.1.5",
+                    "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz",
+                    "integrity": "sha1-jTvGuNo8qBEqFg2NSW/wRiv+948=",
+                    "dev": true,
+                    "requires": {
+                        "homedir-polyfill": "^1.0.0",
+                        "ini": "^1.3.4",
+                        "is-windows": "^0.2.0",
+                        "which": "^1.2.12"
+                    }
+                },
+                "is-accessor-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    },
+                    "dependencies": {
+                        "kind-of": {
+                            "version": "6.0.3",
+                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+                            "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+                            "dev": true
+                        }
+                    }
+                },
+                "is-binary-path": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+                    "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+                    "dev": true,
+                    "requires": {
+                        "binary-extensions": "^1.0.0"
+                    }
+                },
+                "is-data-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    },
+                    "dependencies": {
+                        "kind-of": {
+                            "version": "6.0.3",
+                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+                            "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+                            "dev": true
+                        }
+                    }
+                },
+                "is-descriptor": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+                    "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+                    "dev": true,
+                    "requires": {
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
+                    },
+                    "dependencies": {
+                        "kind-of": {
+                            "version": "6.0.3",
+                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+                            "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+                            "dev": true
+                        }
+                    }
+                },
+                "is-extglob": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+                    "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+                    "dev": true
+                },
+                "is-glob": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+                    "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+                    "dev": true,
+                    "requires": {
+                        "is-extglob": "^1.0.0"
+                    }
+                },
+                "is-number": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+                    "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^3.0.2"
+                    }
+                },
+                "is-windows": {
+                    "version": "0.2.0",
+                    "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
+                    "integrity": "sha1-3hqm1j6indJIc3tp8f+LgALSEIw=",
+                    "dev": true
+                },
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "^1.1.5"
+                    }
+                },
+                "micromatch": {
+                    "version": "2.3.11",
+                    "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+                    "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+                    "dev": true,
+                    "requires": {
+                        "arr-diff": "^2.0.0",
+                        "array-unique": "^0.2.1",
+                        "braces": "^1.8.2",
+                        "expand-brackets": "^0.1.4",
+                        "extglob": "^0.3.1",
+                        "filename-regex": "^2.0.0",
+                        "is-extglob": "^1.0.0",
+                        "is-glob": "^2.0.1",
+                        "kind-of": "^3.0.2",
+                        "normalize-path": "^2.0.1",
+                        "object.omit": "^2.0.0",
+                        "parse-glob": "^3.0.4",
+                        "regex-cache": "^0.4.2"
+                    }
+                },
+                "normalize-path": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+                    "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+                    "dev": true,
+                    "requires": {
+                        "remove-trailing-separator": "^1.0.1"
+                    }
+                },
+                "readdirp": {
+                    "version": "2.2.1",
+                    "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
+                    "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.11",
+                        "micromatch": "^3.1.10",
+                        "readable-stream": "^2.0.2"
+                    },
+                    "dependencies": {
+                        "arr-diff": {
+                            "version": "4.0.0",
+                            "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+                            "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+                            "dev": true
+                        },
+                        "array-unique": {
+                            "version": "0.3.2",
+                            "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+                            "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+                            "dev": true
+                        },
+                        "braces": {
+                            "version": "2.3.2",
+                            "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+                            "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+                            "dev": true,
+                            "requires": {
+                                "arr-flatten": "^1.1.0",
+                                "array-unique": "^0.3.2",
+                                "extend-shallow": "^2.0.1",
+                                "fill-range": "^4.0.0",
+                                "isobject": "^3.0.1",
+                                "repeat-element": "^1.1.2",
+                                "snapdragon": "^0.8.1",
+                                "snapdragon-node": "^2.0.1",
+                                "split-string": "^3.0.2",
+                                "to-regex": "^3.0.1"
+                            },
+                            "dependencies": {
+                                "extend-shallow": {
+                                    "version": "2.0.1",
+                                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                                    "dev": true,
+                                    "requires": {
+                                        "is-extendable": "^0.1.0"
+                                    }
+                                }
+                            }
+                        },
+                        "expand-brackets": {
+                            "version": "2.1.4",
+                            "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+                            "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+                            "dev": true,
+                            "requires": {
+                                "debug": "^2.3.3",
+                                "define-property": "^0.2.5",
+                                "extend-shallow": "^2.0.1",
+                                "posix-character-classes": "^0.1.0",
+                                "regex-not": "^1.0.0",
+                                "snapdragon": "^0.8.1",
+                                "to-regex": "^3.0.1"
+                            },
+                            "dependencies": {
+                                "define-property": {
+                                    "version": "0.2.5",
+                                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+                                    "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                                    "dev": true,
+                                    "requires": {
+                                        "is-descriptor": "^0.1.0"
+                                    }
+                                },
+                                "extend-shallow": {
+                                    "version": "2.0.1",
+                                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                                    "dev": true,
+                                    "requires": {
+                                        "is-extendable": "^0.1.0"
+                                    }
+                                },
+                                "is-descriptor": {
+                                    "version": "0.1.6",
+                                    "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+                                    "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+                                    "dev": true,
+                                    "requires": {
+                                        "is-accessor-descriptor": "^0.1.6",
+                                        "is-data-descriptor": "^0.1.4",
+                                        "kind-of": "^5.0.0"
+                                    }
+                                },
+                                "kind-of": {
+                                    "version": "5.1.0",
+                                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+                                    "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+                                    "dev": true
+                                }
+                            }
+                        },
+                        "extglob": {
+                            "version": "2.0.4",
+                            "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+                            "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+                            "dev": true,
+                            "requires": {
+                                "array-unique": "^0.3.2",
+                                "define-property": "^1.0.0",
+                                "expand-brackets": "^2.1.4",
+                                "extend-shallow": "^2.0.1",
+                                "fragment-cache": "^0.2.1",
+                                "regex-not": "^1.0.0",
+                                "snapdragon": "^0.8.1",
+                                "to-regex": "^3.0.1"
+                            },
+                            "dependencies": {
+                                "define-property": {
+                                    "version": "1.0.0",
+                                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+                                    "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+                                    "dev": true,
+                                    "requires": {
+                                        "is-descriptor": "^1.0.0"
+                                    }
+                                },
+                                "extend-shallow": {
+                                    "version": "2.0.1",
+                                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                                    "dev": true,
+                                    "requires": {
+                                        "is-extendable": "^0.1.0"
+                                    }
+                                }
+                            }
+                        },
+                        "is-accessor-descriptor": {
+                            "version": "0.1.6",
+                            "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+                            "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+                            "dev": true,
+                            "requires": {
+                                "kind-of": "^3.0.2"
+                            },
+                            "dependencies": {
+                                "kind-of": {
+                                    "version": "3.2.2",
+                                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                                    "dev": true,
+                                    "requires": {
+                                        "is-buffer": "^1.1.5"
+                                    }
+                                }
+                            }
+                        },
+                        "is-data-descriptor": {
+                            "version": "0.1.4",
+                            "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+                            "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+                            "dev": true,
+                            "requires": {
+                                "kind-of": "^3.0.2"
+                            },
+                            "dependencies": {
+                                "kind-of": {
+                                    "version": "3.2.2",
+                                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                                    "dev": true,
+                                    "requires": {
+                                        "is-buffer": "^1.1.5"
+                                    }
+                                }
+                            }
+                        },
+                        "kind-of": {
+                            "version": "6.0.3",
+                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+                            "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+                            "dev": true
+                        },
+                        "micromatch": {
+                            "version": "3.1.10",
+                            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+                            "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+                            "dev": true,
+                            "requires": {
+                                "arr-diff": "^4.0.0",
+                                "array-unique": "^0.3.2",
+                                "braces": "^2.3.1",
+                                "define-property": "^2.0.2",
+                                "extend-shallow": "^3.0.2",
+                                "extglob": "^2.0.4",
+                                "fragment-cache": "^0.2.1",
+                                "kind-of": "^6.0.2",
+                                "nanomatch": "^1.2.9",
+                                "object.pick": "^1.3.0",
+                                "regex-not": "^1.0.0",
+                                "snapdragon": "^0.8.1",
+                                "to-regex": "^3.0.2"
+                            }
+                        }
+                    }
+                },
+                "resolve": {
+                    "version": "1.3.2",
+                    "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.2.tgz",
+                    "integrity": "sha1-HwRCyeDLuBNuh7kwX5MvRsfygjU=",
+                    "dev": true,
+                    "requires": {
+                        "path-parse": "^1.0.5"
+                    }
+                },
+                "resolve-dir": {
+                    "version": "0.1.1",
+                    "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz",
+                    "integrity": "sha1-shklmlYC+sXFxJatiUpujMQwJh4=",
+                    "dev": true,
+                    "requires": {
+                        "expand-tilde": "^1.2.2",
+                        "global-modules": "^0.2.3"
+                    }
+                },
+                "to-regex-range": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+                    "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+                    "dev": true,
+                    "requires": {
+                        "is-number": "^3.0.0",
+                        "repeat-string": "^1.6.1"
+                    }
+                }
+            }
+        },
+        "randomatic": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz",
+            "integrity": "sha512-TuDE5KxZ0J461RVjrJZCJc+J+zCkTb1MbH9AQUq68sMhOMcy9jLcb3BrZKgp9q9Ncltdg4QVqWrH02W2EFFVYw==",
+            "dev": true,
+            "requires": {
+                "is-number": "^4.0.0",
+                "kind-of": "^6.0.0",
+                "math-random": "^1.0.1"
+            },
+            "dependencies": {
+                "is-number": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+                    "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+                    "dev": true
+                }
+            }
+        },
+        "randombytes": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+            "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+            "dev": true,
+            "requires": {
+                "safe-buffer": "^5.1.0"
+            }
+        },
+        "randomfill": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
+            "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
+            "dev": true,
+            "requires": {
+                "randombytes": "^2.0.5",
+                "safe-buffer": "^5.1.0"
+            }
+        },
+        "read-only-stream": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/read-only-stream/-/read-only-stream-2.0.0.tgz",
+            "integrity": "sha1-JyT9aoET1zdkrCiNQ4YnDB2/F/A=",
+            "dev": true,
+            "requires": {
+                "readable-stream": "^2.0.2"
+            }
+        },
+        "readable-stream": {
+            "version": "2.3.7",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+            "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+            "dev": true,
+            "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+            },
+            "dependencies": {
+                "safe-buffer": {
+                    "version": "5.1.2",
+                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+                    "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+                    "dev": true
+                },
+                "string_decoder": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+                    "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "~5.1.0"
+                    }
+                }
+            }
+        },
+        "readdirp": {
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+            "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+            "dev": true,
+            "requires": {
+                "picomatch": "^2.2.1"
+            }
+        },
+        "rechoir": {
+            "version": "0.7.1",
+            "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.1.tgz",
+            "integrity": "sha512-/njmZ8s1wVeR6pjTZ+0nCnv8SpZNRMT2D1RLOJQESlYFDBvwpTA4KWJpZ+sBJ4+vhjILRcK7JIFdGCdxEAAitg==",
+            "dev": true,
+            "requires": {
+                "resolve": "^1.9.0"
+            }
+        },
+        "regenerate": {
+            "version": "1.4.2",
+            "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
+            "integrity": "sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==",
+            "dev": true
+        },
+        "regenerate-unicode-properties": {
+            "version": "10.0.1",
+            "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-10.0.1.tgz",
+            "integrity": "sha512-vn5DU6yg6h8hP/2OkQo3K7uVILvY4iu0oI4t3HFa81UPkhGJwkRwM10JEc3upjdhHjs/k8GJY1sRBhk5sr69Bw==",
+            "dev": true,
+            "requires": {
+                "regenerate": "^1.4.2"
+            }
+        },
+        "regenerator-runtime": {
+            "version": "0.13.9",
+            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
+            "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==",
+            "dev": true
+        },
+        "regenerator-transform": {
+            "version": "0.14.5",
+            "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.14.5.tgz",
+            "integrity": "sha512-eOf6vka5IO151Jfsw2NO9WpGX58W6wWmefK3I1zEGr0lOD0u8rwPaNqQL1aRxUaxLeKO3ArNh3VYg1KbaD+FFw==",
+            "dev": true,
+            "requires": {
+                "@babel/runtime": "^7.8.4"
+            }
+        },
+        "regex-cache": {
+            "version": "0.4.4",
+            "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
+            "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+            "dev": true,
+            "requires": {
+                "is-equal-shallow": "^0.1.3"
+            }
+        },
+        "regex-not": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+            "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+            "dev": true,
+            "requires": {
+                "extend-shallow": "^3.0.2",
+                "safe-regex": "^1.1.0"
+            }
+        },
+        "regexpp": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
+            "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
+            "dev": true
+        },
+        "regexpu-core": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-5.0.1.tgz",
+            "integrity": "sha512-CriEZlrKK9VJw/xQGJpQM5rY88BtuL8DM+AEwvcThHilbxiTAy8vq4iJnd2tqq8wLmjbGZzP7ZcKFjbGkmEFrw==",
+            "dev": true,
+            "requires": {
+                "regenerate": "^1.4.2",
+                "regenerate-unicode-properties": "^10.0.1",
+                "regjsgen": "^0.6.0",
+                "regjsparser": "^0.8.2",
+                "unicode-match-property-ecmascript": "^2.0.0",
+                "unicode-match-property-value-ecmascript": "^2.0.0"
+            }
+        },
+        "regjsgen": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.6.0.tgz",
+            "integrity": "sha512-ozE883Uigtqj3bx7OhL1KNbCzGyW2NQZPl6Hs09WTvCuZD5sTI4JY58bkbQWa/Y9hxIsvJ3M8Nbf7j54IqeZbA==",
+            "dev": true
+        },
+        "regjsparser": {
+            "version": "0.8.4",
+            "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.8.4.tgz",
+            "integrity": "sha512-J3LABycON/VNEu3abOviqGHuB/LOtOQj8SKmfP9anY5GfAVw/SPjwzSjxGjbZXIxbGfqTHtJw58C2Li/WkStmA==",
+            "dev": true,
+            "requires": {
+                "jsesc": "~0.5.0"
+            },
+            "dependencies": {
+                "jsesc": {
+                    "version": "0.5.0",
+                    "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+                    "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+                    "dev": true
+                }
+            }
+        },
+        "remove-trailing-separator": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+            "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+            "dev": true
+        },
+        "repeat-element": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.4.tgz",
+            "integrity": "sha512-LFiNfRcSu7KK3evMyYOuCzv3L10TW7yC1G2/+StMjK8Y6Vqd2MG7r/Qjw4ghtuCOjFvlnms/iMmLqpvW/ES/WQ==",
+            "dev": true
+        },
+        "repeat-string": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+            "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+            "dev": true
+        },
+        "replace-ext": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.1.tgz",
+            "integrity": "sha512-yD5BHCe7quCgBph4rMQ+0KkIRKwWCrHDOX1p1Gp6HwjPM5kVoCdKGNhN7ydqqsX6lJEnQDKZ/tFMiEdQ1dvPEw==",
+            "dev": true
+        },
+        "resolve": {
+            "version": "1.22.0",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
+            "integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
+            "dev": true,
+            "requires": {
+                "is-core-module": "^2.8.1",
+                "path-parse": "^1.0.7",
+                "supports-preserve-symlinks-flag": "^1.0.0"
+            }
+        },
+        "resolve-dir": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
+            "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
+            "dev": true,
+            "requires": {
+                "expand-tilde": "^2.0.0",
+                "global-modules": "^1.0.0"
+            }
+        },
+        "resolve-from": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+            "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+            "dev": true
+        },
+        "resolve-url": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+            "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
+            "dev": true
+        },
+        "ret": {
+            "version": "0.1.15",
+            "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+            "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+            "dev": true
+        },
+        "rimraf": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+            "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+            "dev": true,
+            "requires": {
+                "glob": "^7.1.3"
+            }
+        },
+        "ripemd160": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
+            "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
+            "dev": true,
+            "requires": {
+                "hash-base": "^3.0.0",
+                "inherits": "^2.0.1"
+            }
+        },
+        "safe-buffer": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+            "dev": true
+        },
+        "safe-regex": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+            "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+            "dev": true,
+            "requires": {
+                "ret": "~0.1.10"
+            }
+        },
+        "safer-buffer": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+            "dev": true
+        },
+        "sax": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+            "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
+        },
+        "semver": {
+            "version": "5.7.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+            "dev": true
+        },
+        "set-immediate-shim": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+            "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
+            "dev": true
+        },
+        "set-value": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+            "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
+            "dev": true,
+            "requires": {
+                "extend-shallow": "^2.0.1",
+                "is-extendable": "^0.1.1",
+                "is-plain-object": "^2.0.3",
+                "split-string": "^3.0.1"
+            },
+            "dependencies": {
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "dev": true,
+                    "requires": {
+                        "is-extendable": "^0.1.0"
+                    }
+                }
+            }
+        },
+        "sha.js": {
+            "version": "2.4.11",
+            "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+            "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+            "dev": true,
+            "requires": {
+                "inherits": "^2.0.1",
+                "safe-buffer": "^5.0.1"
+            }
+        },
+        "shasum": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/shasum/-/shasum-1.0.2.tgz",
+            "integrity": "sha1-5wEjENj0F/TetXEhUOVni4euVl8=",
+            "dev": true,
+            "requires": {
+                "json-stable-stringify": "~0.0.0",
+                "sha.js": "~2.4.4"
+            }
+        },
+        "shasum-object": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/shasum-object/-/shasum-object-1.0.0.tgz",
+            "integrity": "sha512-Iqo5rp/3xVi6M4YheapzZhhGPVs0yZwHj7wvwQ1B9z8H6zk+FEnI7y3Teq7qwnekfEhu8WmG2z0z4iWZaxLWVg==",
+            "dev": true,
+            "requires": {
+                "fast-safe-stringify": "^2.0.7"
+            }
+        },
+        "shebang-command": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+            "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+            "dev": true,
+            "requires": {
+                "shebang-regex": "^3.0.0"
+            }
+        },
+        "shebang-regex": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+            "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+            "dev": true
+        },
+        "shell-quote": {
+            "version": "1.7.3",
+            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.3.tgz",
+            "integrity": "sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw==",
+            "dev": true
+        },
+        "side-channel": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+            "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+            "dev": true,
+            "requires": {
+                "call-bind": "^1.0.0",
+                "get-intrinsic": "^1.0.2",
+                "object-inspect": "^1.9.0"
+            }
+        },
+        "simple-concat": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+            "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+            "dev": true
+        },
+        "slash": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+            "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+            "dev": true
+        },
+        "snapdragon": {
+            "version": "0.8.2",
+            "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
+            "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+            "dev": true,
+            "requires": {
+                "base": "^0.11.1",
+                "debug": "^2.2.0",
+                "define-property": "^0.2.5",
+                "extend-shallow": "^2.0.1",
+                "map-cache": "^0.2.2",
+                "source-map": "^0.5.6",
+                "source-map-resolve": "^0.5.0",
+                "use": "^3.1.0"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "0.2.5",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+                    "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                    "dev": true,
+                    "requires": {
+                        "is-descriptor": "^0.1.0"
+                    }
+                },
+                "extend-shallow": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                    "dev": true,
+                    "requires": {
+                        "is-extendable": "^0.1.0"
+                    }
+                }
+            }
+        },
+        "snapdragon-node": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+            "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+            "dev": true,
+            "requires": {
+                "define-property": "^1.0.0",
+                "isobject": "^3.0.0",
+                "snapdragon-util": "^3.0.1"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+                    "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+                    "dev": true,
+                    "requires": {
+                        "is-descriptor": "^1.0.0"
+                    }
+                },
+                "is-accessor-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-data-descriptor": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+                    "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^6.0.0"
+                    }
+                },
+                "is-descriptor": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+                    "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+                    "dev": true,
+                    "requires": {
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
+                    }
+                }
+            }
+        },
+        "snapdragon-util": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+            "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+            "dev": true,
+            "requires": {
+                "kind-of": "^3.2.0"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "^1.1.5"
+                    }
+                }
+            }
+        },
+        "source-map": {
+            "version": "0.5.7",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+            "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+            "dev": true
+        },
+        "source-map-resolve": {
+            "version": "0.5.3",
+            "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
+            "integrity": "sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==",
+            "dev": true,
+            "requires": {
+                "atob": "^2.1.2",
+                "decode-uri-component": "^0.2.0",
+                "resolve-url": "^0.2.1",
+                "source-map-url": "^0.4.0",
+                "urix": "^0.1.0"
+            }
+        },
+        "source-map-url": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.1.tgz",
+            "integrity": "sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw==",
+            "dev": true
+        },
+        "split-string": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+            "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+            "dev": true,
+            "requires": {
+                "extend-shallow": "^3.0.0"
+            }
+        },
+        "sprintf-js": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+            "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
+            "dev": true
+        },
+        "static-extend": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+            "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+            "dev": true,
+            "requires": {
+                "define-property": "^0.2.5",
+                "object-copy": "^0.1.0"
+            },
+            "dependencies": {
+                "define-property": {
+                    "version": "0.2.5",
+                    "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+                    "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+                    "dev": true,
+                    "requires": {
+                        "is-descriptor": "^0.1.0"
+                    }
+                }
+            }
+        },
+        "stream-browserify": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.2.tgz",
+            "integrity": "sha512-nX6hmklHs/gr2FuxYDltq8fJA1GDlxKQCz8O/IM4atRqBH8OORmBNgfvW5gG10GT/qQ9u0CzIvr2X5Pkt6ntqg==",
+            "dev": true,
+            "requires": {
+                "inherits": "~2.0.1",
+                "readable-stream": "^2.0.2"
+            }
+        },
+        "stream-combiner2": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
+            "integrity": "sha1-+02KFCDqNidk4hrUeAOXvry0HL4=",
+            "dev": true,
+            "requires": {
+                "duplexer2": "~0.1.0",
+                "readable-stream": "^2.0.2"
+            }
+        },
+        "stream-http": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-3.2.0.tgz",
+            "integrity": "sha512-Oq1bLqisTyK3TSCXpPbT4sdeYNdmyZJv1LxpEm2vu1ZhK89kSE5YXwZc3cWk0MagGaKriBh9mCFbVGtO+vY29A==",
+            "dev": true,
+            "requires": {
+                "builtin-status-codes": "^3.0.0",
+                "inherits": "^2.0.4",
+                "readable-stream": "^3.6.0",
+                "xtend": "^4.0.2"
+            },
+            "dependencies": {
+                "readable-stream": {
+                    "version": "3.6.0",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+                    "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+                    "dev": true,
+                    "requires": {
+                        "inherits": "^2.0.3",
+                        "string_decoder": "^1.1.1",
+                        "util-deprecate": "^1.0.1"
+                    }
+                }
+            }
+        },
+        "stream-splicer": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-2.0.1.tgz",
+            "integrity": "sha512-Xizh4/NPuYSyAXyT7g8IvdJ9HJpxIGL9PjyhtywCZvvP0OPIdqyrr4dMikeuvY8xahpdKEBlBTySe583totajg==",
+            "dev": true,
+            "requires": {
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.0.2"
+            }
+        },
+        "string.prototype.trimend": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+            "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+            "dev": true,
+            "requires": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.3"
+            }
+        },
+        "string.prototype.trimstart": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+            "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+            "dev": true,
+            "requires": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.3"
+            }
+        },
+        "string_decoder": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+            "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+            "dev": true,
+            "requires": {
+                "safe-buffer": "~5.2.0"
+            }
+        },
+        "strip-ansi": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+            "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+            "dev": true,
+            "requires": {
+                "ansi-regex": "^2.0.0"
+            }
+        },
+        "subarg": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
+            "integrity": "sha1-9izxdYHplrSPyWVpn1TAauJouNI=",
+            "dev": true,
+            "requires": {
+                "minimist": "^1.1.0"
+            }
+        },
+        "supports-color": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+            "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+            "dev": true
+        },
+        "supports-preserve-symlinks-flag": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+            "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+            "dev": true
+        },
+        "syntax-error": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.4.0.tgz",
+            "integrity": "sha512-YPPlu67mdnHGTup2A8ff7BC2Pjq0e0Yp/IyTFN03zWO0RcK07uLcbi7C2KpGR2FvWbaB0+bfE27a+sBKebSo7w==",
+            "dev": true,
+            "requires": {
+                "acorn-node": "^1.2.0"
+            }
+        },
+        "text-table": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+            "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+            "dev": true
+        },
+        "through": {
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+            "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+            "dev": true
+        },
+        "through2": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+            "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+            "dev": true,
+            "requires": {
+                "readable-stream": "~2.3.6",
+                "xtend": "~4.0.1"
+            }
+        },
+        "timers-browserify": {
+            "version": "1.4.2",
+            "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz",
+            "integrity": "sha1-ycWLV1voQHN1y14kYtrO50NZ9B0=",
+            "dev": true,
+            "requires": {
+                "process": "~0.11.0"
+            }
+        },
+        "to-fast-properties": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+            "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+            "dev": true
+        },
+        "to-object-path": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+            "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+            "dev": true,
+            "requires": {
+                "kind-of": "^3.0.2"
+            },
+            "dependencies": {
+                "kind-of": {
+                    "version": "3.2.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                    "dev": true,
+                    "requires": {
+                        "is-buffer": "^1.1.5"
+                    }
+                }
+            }
+        },
+        "to-regex": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+            "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+            "dev": true,
+            "requires": {
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "regex-not": "^1.0.2",
+                "safe-regex": "^1.1.0"
+            }
+        },
+        "to-regex-range": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+            "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+            "dev": true,
+            "requires": {
+                "is-number": "^7.0.0"
+            }
+        },
+        "trim-right": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+            "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+            "dev": true
+        },
+        "tty-browserify": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.1.tgz",
+            "integrity": "sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw==",
+            "dev": true
+        },
+        "type-check": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+            "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+            "dev": true,
+            "requires": {
+                "prelude-ls": "^1.2.1"
+            }
+        },
+        "type-fest": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+            "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+            "dev": true
+        },
+        "typedarray": {
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+            "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+            "dev": true
+        },
+        "umd": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/umd/-/umd-3.0.3.tgz",
+            "integrity": "sha512-4IcGSufhFshvLNcMCV80UnQVlZ5pMOC8mvNPForqwA4+lzYQuetTESLDQkeLmihq8bRcnpbQa48Wb8Lh16/xow==",
+            "dev": true
+        },
+        "unbox-primitive": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
+            "integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
+            "dev": true,
+            "requires": {
+                "function-bind": "^1.1.1",
+                "has-bigints": "^1.0.1",
+                "has-symbols": "^1.0.2",
+                "which-boxed-primitive": "^1.0.2"
+            }
+        },
+        "unc-path-regex": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
+            "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo=",
+            "dev": true
+        },
+        "undeclared-identifiers": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/undeclared-identifiers/-/undeclared-identifiers-1.1.3.tgz",
+            "integrity": "sha512-pJOW4nxjlmfwKApE4zvxLScM/njmwj/DiUBv7EabwE4O8kRUy+HIwxQtZLBPll/jx1LJyBcqNfB3/cpv9EZwOw==",
+            "dev": true,
+            "requires": {
+                "acorn-node": "^1.3.0",
+                "dash-ast": "^1.0.0",
+                "get-assigned-identifiers": "^1.2.0",
+                "simple-concat": "^1.0.0",
+                "xtend": "^4.0.1"
+            }
+        },
+        "underscore.string": {
+            "version": "3.3.6",
+            "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.6.tgz",
+            "integrity": "sha512-VoC83HWXmCrF6rgkyxS9GHv8W9Q5nhMKho+OadDJGzL2oDYbYEppBaCMH6pFlwLeqj2QS+hhkw2kpXkSdD1JxQ==",
+            "dev": true,
+            "requires": {
+                "sprintf-js": "^1.1.1",
+                "util-deprecate": "^1.0.2"
+            }
+        },
+        "unicode-canonical-property-names-ecmascript": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.0.tgz",
+            "integrity": "sha512-yY5PpDlfVIU5+y/BSCxAJRBIS1Zc2dDG3Ujq+sR0U+JjUevW2JhocOF+soROYDSaAezOzOKuyyixhD6mBknSmQ==",
+            "dev": true
+        },
+        "unicode-match-property-ecmascript": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-2.0.0.tgz",
+            "integrity": "sha512-5kaZCrbp5mmbz5ulBkDkbY0SsPOjKqVS35VpL9ulMPfSl0J0Xsm+9Evphv9CoIZFwre7aJoa94AY6seMKGVN5Q==",
+            "dev": true,
+            "requires": {
+                "unicode-canonical-property-names-ecmascript": "^2.0.0",
+                "unicode-property-aliases-ecmascript": "^2.0.0"
+            }
+        },
+        "unicode-match-property-value-ecmascript": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-2.0.0.tgz",
+            "integrity": "sha512-7Yhkc0Ye+t4PNYzOGKedDhXbYIBe1XEQYQxOPyhcXNMJ0WCABqqj6ckydd6pWRZTHV4GuCPKdBAUiMc60tsKVw==",
+            "dev": true
+        },
+        "unicode-property-aliases-ecmascript": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.0.0.tgz",
+            "integrity": "sha512-5Zfuy9q/DFr4tfO7ZPeVXb1aPoeQSdeFMLpYuFebehDAhbuevLs5yxSZmIFN1tP5F9Wl4IpJrYojg85/zgyZHQ==",
+            "dev": true
+        },
+        "union-value": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
+            "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
+            "dev": true,
+            "requires": {
+                "arr-union": "^3.1.0",
+                "get-value": "^2.0.6",
+                "is-extendable": "^0.1.1",
+                "set-value": "^2.0.1"
+            }
+        },
+        "universalify": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+            "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+            "dev": true
+        },
+        "unset-value": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+            "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+            "dev": true,
+            "requires": {
+                "has-value": "^0.3.1",
+                "isobject": "^3.0.0"
+            },
+            "dependencies": {
+                "has-value": {
+                    "version": "0.3.1",
+                    "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+                    "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+                    "dev": true,
+                    "requires": {
+                        "get-value": "^2.0.3",
+                        "has-values": "^0.1.4",
+                        "isobject": "^2.0.0"
+                    },
+                    "dependencies": {
+                        "isobject": {
+                            "version": "2.1.0",
+                            "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+                            "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+                            "dev": true,
+                            "requires": {
+                                "isarray": "1.0.0"
+                            }
+                        }
+                    }
+                },
+                "has-values": {
+                    "version": "0.1.4",
+                    "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+                    "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+                    "dev": true
+                }
+            }
+        },
+        "uri-js": {
+            "version": "4.4.1",
+            "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+            "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+            "dev": true,
+            "requires": {
+                "punycode": "^2.1.0"
+            },
+            "dependencies": {
+                "punycode": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+                    "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+                    "dev": true
+                }
+            }
+        },
+        "urix": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+            "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+            "dev": true
+        },
+        "url": {
+            "version": "0.11.0",
+            "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+            "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
+            "dev": true,
+            "requires": {
+                "punycode": "1.3.2",
+                "querystring": "0.2.0"
+            },
+            "dependencies": {
+                "punycode": {
+                    "version": "1.3.2",
+                    "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+                    "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
+                    "dev": true
+                }
+            }
+        },
+        "use": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
+            "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
+            "dev": true
+        },
+        "util": {
+            "version": "0.10.4",
+            "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
+            "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
+            "dev": true,
+            "requires": {
+                "inherits": "2.0.3"
+            },
+            "dependencies": {
+                "inherits": {
+                    "version": "2.0.3",
+                    "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                    "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+                    "dev": true
+                }
+            }
+        },
+        "util-deprecate": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+            "dev": true
+        },
+        "v8-compile-cache": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
+            "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
+            "dev": true
+        },
+        "v8flags": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.2.0.tgz",
+            "integrity": "sha512-mH8etigqMfiGWdeXpaaqGfs6BndypxusHHcv2qSHyZkGEznCd/qAXCWWRzeowtL54147cktFOC4P5y+kl8d8Jg==",
+            "dev": true,
+            "requires": {
+                "homedir-polyfill": "^1.0.1"
+            }
+        },
+        "vinyl": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.1.tgz",
+            "integrity": "sha512-LII3bXRFBZLlezoG5FfZVcXflZgWP/4dCwKtxd5ky9+LOtM4CS3bIRQsmR1KMnMW07jpE8fqR2lcxPZ+8sJIcw==",
+            "dev": true,
+            "requires": {
+                "clone": "^2.1.1",
+                "clone-buffer": "^1.0.0",
+                "clone-stats": "^1.0.0",
+                "cloneable-readable": "^1.0.0",
+                "remove-trailing-separator": "^1.0.1",
+                "replace-ext": "^1.0.0"
+            }
+        },
+        "vinyl-sourcemaps-apply": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.1.tgz",
+            "integrity": "sha1-q2VJ1h0XLCsbh75cUI0jnI74dwU=",
+            "dev": true,
+            "requires": {
+                "source-map": "^0.5.1"
+            }
+        },
+        "vm-browserify": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
+            "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==",
+            "dev": true
+        },
+        "walk-sync": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.3.1.tgz",
+            "integrity": "sha1-VYoWrqyMDbWcAotzxm85doTs5GU=",
+            "dev": true,
+            "requires": {
+                "ensure-posix-path": "^1.0.0",
+                "matcher-collection": "^1.0.0"
+            }
+        },
+        "watchify": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/watchify/-/watchify-4.0.0.tgz",
+            "integrity": "sha512-2Z04dxwoOeNxa11qzWumBTgSAohTC0+ScuY7XMenPnH+W2lhTcpEOJP4g2EIG/SWeLadPk47x++Yh+8BqPM/lA==",
+            "dev": true,
+            "requires": {
+                "anymatch": "^3.1.0",
+                "browserify": "^17.0.0",
+                "chokidar": "^3.4.0",
+                "defined": "^1.0.0",
+                "outpipe": "^1.1.0",
+                "through2": "^4.0.2",
+                "xtend": "^4.0.2"
+            },
+            "dependencies": {
+                "browserify": {
+                    "version": "17.0.0",
+                    "resolved": "https://registry.npmjs.org/browserify/-/browserify-17.0.0.tgz",
+                    "integrity": "sha512-SaHqzhku9v/j6XsQMRxPyBrSP3gnwmE27gLJYZgMT2GeK3J0+0toN+MnuNYDfHwVGQfLiMZ7KSNSIXHemy905w==",
+                    "dev": true,
+                    "requires": {
+                        "JSONStream": "^1.0.3",
+                        "assert": "^1.4.0",
+                        "browser-pack": "^6.0.1",
+                        "browser-resolve": "^2.0.0",
+                        "browserify-zlib": "~0.2.0",
+                        "buffer": "~5.2.1",
+                        "cached-path-relative": "^1.0.0",
+                        "concat-stream": "^1.6.0",
+                        "console-browserify": "^1.1.0",
+                        "constants-browserify": "~1.0.0",
+                        "crypto-browserify": "^3.0.0",
+                        "defined": "^1.0.0",
+                        "deps-sort": "^2.0.1",
+                        "domain-browser": "^1.2.0",
+                        "duplexer2": "~0.1.2",
+                        "events": "^3.0.0",
+                        "glob": "^7.1.0",
+                        "has": "^1.0.0",
+                        "htmlescape": "^1.1.0",
+                        "https-browserify": "^1.0.0",
+                        "inherits": "~2.0.1",
+                        "insert-module-globals": "^7.2.1",
+                        "labeled-stream-splicer": "^2.0.0",
+                        "mkdirp-classic": "^0.5.2",
+                        "module-deps": "^6.2.3",
+                        "os-browserify": "~0.3.0",
+                        "parents": "^1.0.1",
+                        "path-browserify": "^1.0.0",
+                        "process": "~0.11.0",
+                        "punycode": "^1.3.2",
+                        "querystring-es3": "~0.2.0",
+                        "read-only-stream": "^2.0.0",
+                        "readable-stream": "^2.0.2",
+                        "resolve": "^1.1.4",
+                        "shasum-object": "^1.0.0",
+                        "shell-quote": "^1.6.1",
+                        "stream-browserify": "^3.0.0",
+                        "stream-http": "^3.0.0",
+                        "string_decoder": "^1.1.1",
+                        "subarg": "^1.0.0",
+                        "syntax-error": "^1.1.1",
+                        "through2": "^2.0.0",
+                        "timers-browserify": "^1.0.1",
+                        "tty-browserify": "0.0.1",
+                        "url": "~0.11.0",
+                        "util": "~0.12.0",
+                        "vm-browserify": "^1.0.0",
+                        "xtend": "^4.0.0"
+                    },
+                    "dependencies": {
+                        "through2": {
+                            "version": "2.0.5",
+                            "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+                            "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+                            "dev": true,
+                            "requires": {
+                                "readable-stream": "~2.3.6",
+                                "xtend": "~4.0.1"
+                            }
+                        }
+                    }
+                },
+                "events": {
+                    "version": "3.3.0",
+                    "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+                    "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+                    "dev": true
+                },
+                "path-browserify": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+                    "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+                    "dev": true
+                },
+                "stream-browserify": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-3.0.0.tgz",
+                    "integrity": "sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==",
+                    "dev": true,
+                    "requires": {
+                        "inherits": "~2.0.4",
+                        "readable-stream": "^3.5.0"
+                    },
+                    "dependencies": {
+                        "readable-stream": {
+                            "version": "3.6.0",
+                            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+                            "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+                            "dev": true,
+                            "requires": {
+                                "inherits": "^2.0.3",
+                                "string_decoder": "^1.1.1",
+                                "util-deprecate": "^1.0.1"
+                            }
+                        }
+                    }
+                },
+                "through2": {
+                    "version": "4.0.2",
+                    "resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
+                    "integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
+                    "dev": true,
+                    "requires": {
+                        "readable-stream": "3"
+                    },
+                    "dependencies": {
+                        "readable-stream": {
+                            "version": "3.6.0",
+                            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+                            "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+                            "dev": true,
+                            "requires": {
+                                "inherits": "^2.0.3",
+                                "string_decoder": "^1.1.1",
+                                "util-deprecate": "^1.0.1"
+                            }
+                        }
+                    }
+                },
+                "util": {
+                    "version": "0.12.4",
+                    "resolved": "https://registry.npmjs.org/util/-/util-0.12.4.tgz",
+                    "integrity": "sha512-bxZ9qtSlGUWSOy9Qa9Xgk11kSslpuZwaxCg4sNIDj6FLucDab2JxnHwyNTCpHMtK1MjoQiWQ6DiUMZYbSrO+Sw==",
+                    "dev": true,
+                    "requires": {
+                        "inherits": "^2.0.3",
+                        "is-arguments": "^1.0.4",
+                        "is-generator-function": "^1.0.7",
+                        "is-typed-array": "^1.1.3",
+                        "safe-buffer": "^5.1.2",
+                        "which-typed-array": "^1.1.2"
+                    }
+                }
+            }
+        },
+        "which": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+            "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+            "dev": true,
+            "requires": {
+                "isexe": "^2.0.0"
+            }
+        },
+        "which-boxed-primitive": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
+            "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+            "dev": true,
+            "requires": {
+                "is-bigint": "^1.0.1",
+                "is-boolean-object": "^1.1.0",
+                "is-number-object": "^1.0.4",
+                "is-string": "^1.0.5",
+                "is-symbol": "^1.0.3"
+            }
+        },
+        "which-typed-array": {
+            "version": "1.1.7",
+            "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.7.tgz",
+            "integrity": "sha512-vjxaB4nfDqwKI0ws7wZpxIlde1XrLX5uB0ZjpfshgmapJMD7jJWhZI+yToJTqaFByF0eNBcYxbjmCzoRP7CfEw==",
+            "dev": true,
+            "requires": {
+                "available-typed-arrays": "^1.0.5",
+                "call-bind": "^1.0.2",
+                "es-abstract": "^1.18.5",
+                "foreach": "^2.0.5",
+                "has-tostringtag": "^1.0.0",
+                "is-typed-array": "^1.1.7"
+            }
+        },
+        "word-wrap": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+            "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+            "dev": true
+        },
+        "wrappy": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+            "dev": true
+        },
+        "xtend": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+            "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+            "dev": true
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -27,19 +27,32 @@
     "main": "src/main/js/main.js",
     "unpkg": "dist/imsc.min.js",
     "scripts": {
-        "prepublishOnly": "grunt build:release"
+        "prepublishOnly": "grunt build:release",
+        "transpile:babel:umd": "babel src/main/js -d dist/umd",
+        "build:babel:umd": "babel src/main/js --out-file dist/umd2/imsc.js",
+        "lint": "eslint src/main",
+        "lint:fix": "npm run lint -- --fix"
     },
     "dependencies": {
         "sax": "1.2.1"
     },
     "devDependencies": {
+        "@babel/cli": "^7.17.6",
+        "@babel/core": "^7.17.5",
+        "@babel/plugin-transform-modules-umd": "7.16.7",
+        "@babel/preset-env": "^7.16.11",
+        "@babel/preset-es2015": "7.0.0-beta.53",
+        "@types/eslint": "8.4.1",
+        "babelify": "10.0.0",
         "browserify": "^16.2.3",
+        "eslint": "^8.10.0",
         "filesaver.js-npm": "latest",
         "google-closure-compiler": "^20180910.1.0",
         "grunt": "latest",
+        "grunt-babel": "^8.0.0",
         "grunt-browserify": "latest",
         "grunt-contrib-clean": "latest",
-        "grunt-contrib-jshint": "latest",
+        "grunt-eslint": "^24.0.0",
         "grunt-exec": "^3.0.0",
         "grunt-npmcopy": "latest",
         "grunt-sync": "latest",

--- a/src/main/js/doc.js
+++ b/src/main/js/doc.js
@@ -28,1832 +28,1795 @@
  * @module imscDoc
  */
 
-;
-(function (imscDoc, sax, imscNames, imscStyles, imscUtils) {
+const imscDoc = {};
+sax = typeof sax === 'undefined' ? require('sax') : sax; // must be defined this way to make it UMD peer dependency
+const imscNames = require('./names');
+const imscStyles = require('./styles');
+const imscUtils = require('./utils');
+const {reportFatal, reportError, reportWarning} = require('./error');
 
 
-    /**
-     * Allows a client to provide callbacks to handle children of the <metadata> element
-     * @typedef {Object} MetadataHandler
-     * @property {?OpenTagCallBack} onOpenTag
-     * @property {?CloseTagCallBack} onCloseTag
-     * @property {?TextCallBack} onText
-     */
+/**
+ * Allows a client to provide callbacks to handle children of the <metadata> element
+ * @typedef {Object} MetadataHandler
+ * @property {?OpenTagCallBack} onOpenTag
+ * @property {?CloseTagCallBack} onCloseTag
+ * @property {?TextCallBack} onText
+ */
 
-    /**
-     * Called when the opening tag of an element node is encountered.
-     * @callback OpenTagCallBack
-     * @param {string} ns Namespace URI of the element
-     * @param {string} name Local name of the element
-     * @param {Object[]} attributes List of attributes, each consisting of a
-     *                              `uri`, `name` and `value`
-     */
+/**
+ * Called when the opening tag of an element node is encountered.
+ * @callback OpenTagCallBack
+ * @param {string} ns Namespace URI of the element
+ * @param {string} name Local name of the element
+ * @param {Object[]} attributes List of attributes, each consisting of a
+ *                              `uri`, `name` and `value`
+ */
 
-    /**
-     * Called when the closing tag of an element node is encountered.
-     * @callback CloseTagCallBack
-     */
+/**
+ * Called when the closing tag of an element node is encountered.
+ * @callback CloseTagCallBack
+ */
 
-    /**
-     * Called when a text node is encountered.
-     * @callback TextCallBack
-     * @param {string} contents Contents of the text node
-     */
+/**
+ * Called when a text node is encountered.
+ * @callback TextCallBack
+ * @param {string} contents Contents of the text node
+ */
 
-    /**
-     * Parses an IMSC1 document into an opaque in-memory representation that exposes
-     * a single method <pre>getMediaTimeEvents()</pre> that returns a list of time
-     * offsets (in seconds) of the ISD, i.e. the points in time where the visual
-     * representation of the document change. `metadataHandler` allows the caller to
-     * be called back when nodes are present in <metadata> elements. 
-     * 
-     * @param {string} xmlstring XML document
-     * @param {?module:imscUtils.ErrorHandler} errorHandler Error callback
-     * @param {?MetadataHandler} metadataHandler Callback for <Metadata> elements
-     * @returns {Object} Opaque in-memory representation of an IMSC1 document
-     */
+/**
+ * Parses an IMSC1 document into an opaque in-memory representation that exposes
+ * a single method <pre>getMediaTimeEvents()</pre> that returns a list of time
+ * offsets (in seconds) of the ISD, i.e. the points in time where the visual
+ * representation of the document change. `metadataHandler` allows the caller to
+ * be called back when nodes are present in <metadata> elements.
+ *
+ * @param {string} xmlstring XML document
+ * @param {?module:imscUtils.ErrorHandler} errorHandler Error callback
+ * @param {?MetadataHandler} metadataHandler Callback for <Metadata> elements
+ * @returns {Object} Opaque in-memory representation of an IMSC1 document
+ */
 
-    imscDoc.fromXML = function (xmlstring, errorHandler, metadataHandler) {
-        var p = sax.parser(true, {xmlns: true});
-        var estack = [];
-        var xmllangstack = [];
-        var xmlspacestack = [];
-        var metadata_depth = 0;
-        var doc = null;
+imscDoc.fromXML = function (xmlstring, errorHandler, metadataHandler) {
+    var p = sax.parser(true, {xmlns: true});
+    var estack = [];
+    var xmllangstack = [];
+    var xmlspacestack = [];
+    var metadata_depth = 0;
+    var doc = null;
 
-        p.onclosetag = function (node) {
+    p.onclosetag = function () { // function (node) {
 
-            
-            if (estack[0] instanceof Region) {
 
-                /* merge referenced styles */
+        if (estack[0] instanceof Region) {
 
-                if (doc.head !== null && doc.head.styling !== null) {
-                    mergeReferencedStyles(doc.head.styling, estack[0].styleRefs, estack[0].styleAttrs, errorHandler);
-                }
+            /* merge referenced styles */
 
-                delete estack[0].styleRefs;
+            if (doc.head !== null && doc.head.styling !== null) {
+                mergeReferencedStyles(doc.head.styling, estack[0].styleRefs, estack[0].styleAttrs, errorHandler);
+            }
 
-            } else if (estack[0] instanceof Styling) {
+            delete estack[0].styleRefs;
 
-                /* flatten chained referential styling */
+        } else if (estack[0] instanceof Styling) {
 
-                for (var sid in estack[0].styles) {
+            /* flatten chained referential styling */
 
-                    if (! estack[0].styles.hasOwnProperty(sid)) continue;
+            for (var sid in estack[0].styles) {
 
-                    mergeChainedStyles(estack[0], estack[0].styles[sid], errorHandler);
+                if (!  imscUtils.checkHasOwnProperty(estack[0].styles, sid)) continue;
 
-                }
-
-            } else if (estack[0] instanceof P || estack[0] instanceof Span) {
-
-                /* merge anonymous spans */
-
-                if (estack[0].contents.length > 1) {
-
-                    var cs = [estack[0].contents[0]];
-
-                    var c;
-
-                    for (c = 1; c < estack[0].contents.length; c++) {
-
-                        if (estack[0].contents[c] instanceof AnonymousSpan &&
-                                cs[cs.length - 1] instanceof AnonymousSpan) {
-
-                            cs[cs.length - 1].text += estack[0].contents[c].text;
-
-                        } else {
-
-                            cs.push(estack[0].contents[c]);
-
-                        }
-
-                    }
-
-                    estack[0].contents = cs;
-
-                }
-
-                // remove redundant nested anonymous spans (9.3.3(1)(c))
-
-                if (estack[0] instanceof Span &&
-                        estack[0].contents.length === 1 &&
-                        estack[0].contents[0] instanceof AnonymousSpan) {
-
-                    estack[0].text = estack[0].contents[0].text;
-                    delete estack[0].contents;
-
-                }
-
-            } else if (estack[0] instanceof ForeignElement) {
-
-                if (estack[0].node.uri === imscNames.ns_tt &&
-                        estack[0].node.local === 'metadata') {
-
-                    /* leave the metadata element */
-
-                    metadata_depth--;
-
-                } else if (metadata_depth > 0 &&
-                        metadataHandler &&
-                        'onCloseTag' in metadataHandler) {
-
-                    /* end of child of metadata element */
-
-                    metadataHandler.onCloseTag();
-
-                }
+                mergeChainedStyles(estack[0], estack[0].styles[sid], errorHandler);
 
             }
 
-            // TODO: delete stylerefs?
+        } else if (estack[0] instanceof P || estack[0] instanceof Span) {
 
-            // maintain the xml:space stack
+            /* merge anonymous spans */
 
-            xmlspacestack.shift();
+            if (estack[0].contents.length > 1) {
 
-            // maintain the xml:lang stack
+                var cs = [estack[0].contents[0]];
 
-            xmllangstack.shift();
+                var c;
 
-            // prepare for the next element
+                for (c = 1; c < estack[0].contents.length; c++) {
 
-            estack.shift();
-        };
+                    if (estack[0].contents[c] instanceof AnonymousSpan &&
+                        cs[cs.length - 1] instanceof AnonymousSpan) {
 
-        p.ontext = function (str) {
-
-            if (estack[0] === undefined) {
-
-                /* ignoring text outside of elements */
-
-            } else if (estack[0] instanceof Span || estack[0] instanceof P) {
-
-                /* ignore children text nodes in ruby container spans */
-
-                if (estack[0] instanceof Span) {
-
-                    var ruby = estack[0].styleAttrs[imscStyles.byName.ruby.qname];
-
-                    if (ruby === 'container' || ruby === 'textContainer' || ruby === 'baseContainer') {
-
-                        return;
-
-                    }
-
-                }
-
-                /* create an anonymous span */
-
-                var s = new AnonymousSpan();
-
-                s.initFromText(doc, estack[0], str, xmllangstack[0], xmlspacestack[0], errorHandler);
-
-                estack[0].contents.push(s);
-
-            } else if (estack[0] instanceof ForeignElement &&
-                    metadata_depth > 0 &&
-                    metadataHandler &&
-                    'onText' in metadataHandler) {
-
-                /* text node within a child of metadata element */
-
-                metadataHandler.onText(str);
-
-            }
-
-        };
-
-
-        p.onopentag = function (node) {
-
-            // maintain the xml:space stack
-
-            var xmlspace = node.attributes["xml:space"];
-
-            if (xmlspace) {
-
-                xmlspacestack.unshift(xmlspace.value);
-
-            } else {
-
-                if (xmlspacestack.length === 0) {
-
-                    xmlspacestack.unshift("default");
-
-                } else {
-
-                    xmlspacestack.unshift(xmlspacestack[0]);
-
-                }
-
-            }
-
-            /* maintain the xml:lang stack */
-
-
-            var xmllang = node.attributes["xml:lang"];
-
-            if (xmllang) {
-
-                xmllangstack.unshift(xmllang.value);
-
-            } else {
-
-                if (xmllangstack.length === 0) {
-
-                    xmllangstack.unshift("");
-
-                } else {
-
-                    xmllangstack.unshift(xmllangstack[0]);
-
-                }
-
-            }
-
-
-            /* process the element */
-
-            if (node.uri === imscNames.ns_tt) {
-
-                if (node.local === 'tt') {
-
-                    if (doc !== null) {
-
-                        reportFatal(errorHandler, "Two <tt> elements at (" + this.line + "," + this.column + ")");
-
-                    }
-
-                    doc = new TT();
-
-                    doc.initFromNode(node, xmllangstack[0], errorHandler);
-
-                    estack.unshift(doc);
-
-                } else if (node.local === 'head') {
-
-                    if (!(estack[0] instanceof TT)) {
-                        reportFatal(errorHandler, "Parent of <head> element is not <tt> at (" + this.line + "," + this.column + ")");
-                    }
-
-                    estack.unshift(doc.head);
-
-                } else if (node.local === 'styling') {
-
-                    if (!(estack[0] instanceof Head)) {
-                        reportFatal(errorHandler, "Parent of <styling> element is not <head> at (" + this.line + "," + this.column + ")");
-                    }
-
-                    estack.unshift(doc.head.styling);
-
-                } else if (node.local === 'style') {
-
-                    var s;
-
-                    if (estack[0] instanceof Styling) {
-
-                        s = new Style();
-
-                        s.initFromNode(node, errorHandler);
-
-                        /* ignore <style> element missing @id */
-
-                        if (!s.id) {
-
-                            reportError(errorHandler, "<style> element missing @id attribute");
-
-                        } else {
-
-                            doc.head.styling.styles[s.id] = s;
-
-                        }
-
-                        estack.unshift(s);
-
-                    } else if (estack[0] instanceof Region) {
-
-                        /* nested styles can be merged with specified styles
-                         * immediately, with lower priority
-                         * (see 8.4.4.2(3) at TTML1 )
-                         */
-
-                        s = new Style();
-
-                        s.initFromNode(node, errorHandler);
-
-                        mergeStylesIfNotPresent(s.styleAttrs, estack[0].styleAttrs);
-
-                        estack.unshift(s);
+                        cs[cs.length - 1].text += estack[0].contents[c].text;
 
                     } else {
 
-                        reportFatal(errorHandler, "Parent of <style> element is not <styling> or <region> at (" + this.line + "," + this.column + ")");
+                        cs.push(estack[0].contents[c]);
 
                     }
 
-                }  else if (node.local === 'initial') {
-
-                    var ini;
-
-                    if (estack[0] instanceof Styling) {
-
-                        ini = new Initial();
-
-                        ini.initFromNode(node, errorHandler);
-                        
-                        for (var qn in ini.styleAttrs) {
-
-                            if (! ini.styleAttrs.hasOwnProperty(qn)) continue;
-                            
-                            doc.head.styling.initials[qn] = ini.styleAttrs[qn];
-                            
-                        }
-                        
-                        estack.unshift(ini);
-
-                    } else {
-
-                        reportFatal(errorHandler, "Parent of <initial> element is not <styling> at (" + this.line + "," + this.column + ")");
-
-                    }
-
-                } else if (node.local === 'layout') {
-
-                    if (!(estack[0] instanceof Head)) {
-
-                        reportFatal(errorHandler, "Parent of <layout> element is not <head> at " + this.line + "," + this.column + ")");
-
-                    }
-
-                    estack.unshift(doc.head.layout);
-
-                } else if (node.local === 'region') {
-
-                    if (!(estack[0] instanceof Layout)) {
-                        reportFatal(errorHandler, "Parent of <region> element is not <layout> at " + this.line + "," + this.column + ")");
-                    }
-
-                    var r = new Region();
-
-                    r.initFromNode(doc, node, xmllangstack[0], errorHandler);
-
-                    if (!r.id || r.id in doc.head.layout.regions) {
-
-                        reportError(errorHandler, "Ignoring <region> with duplicate or missing @id at " + this.line + "," + this.column + ")");
-
-                    } else {
-
-                        doc.head.layout.regions[r.id] = r;
-
-                    }
-
-                    estack.unshift(r);
-
-                } else if (node.local === 'body') {
-
-                    if (!(estack[0] instanceof TT)) {
-
-                        reportFatal(errorHandler, "Parent of <body> element is not <tt> at " + this.line + "," + this.column + ")");
-
-                    }
-
-                    if (doc.body !== null) {
-
-                        reportFatal(errorHandler, "Second <body> element at " + this.line + "," + this.column + ")");
-
-                    }
-
-                    var b = new Body();
-
-                    b.initFromNode(doc, node, xmllangstack[0], errorHandler);
-
-                    doc.body = b;
-
-                    estack.unshift(b);
-
-                } else if (node.local === 'div') {
-
-                    if (!(estack[0] instanceof Div || estack[0] instanceof Body)) {
-
-                        reportFatal(errorHandler, "Parent of <div> element is not <body> or <div> at " + this.line + "," + this.column + ")");
-
-                    }
-
-                    var d = new Div();
-
-                    d.initFromNode(doc, estack[0], node, xmllangstack[0], errorHandler);
-                    
-                    /* transform smpte:backgroundImage to TTML2 image element */
-                    
-                    var bi = d.styleAttrs[imscStyles.byName.backgroundImage.qname];
-                    
-                    if (bi) {
-                        d.contents.push(new Image(bi));
-                        delete d.styleAttrs[imscStyles.byName.backgroundImage.qname];                  
-                    }
-
-                    estack[0].contents.push(d);
-
-                    estack.unshift(d);
-
-                } else if (node.local === 'image') {
-
-                    if (!(estack[0] instanceof Div)) {
-
-                        reportFatal(errorHandler, "Parent of <image> element is not <div> at " + this.line + "," + this.column + ")");
-
-                    }
-
-                    var img = new Image();
-                    
-                    img.initFromNode(doc, estack[0], node, xmllangstack[0], errorHandler);
-                    
-                    estack[0].contents.push(img);
-
-                    estack.unshift(img);
-
-                } else if (node.local === 'p') {
-
-                    if (!(estack[0] instanceof Div)) {
-
-                        reportFatal(errorHandler, "Parent of <p> element is not <div> at " + this.line + "," + this.column + ")");
-
-                    }
-
-                    var p = new P();
-
-                    p.initFromNode(doc, estack[0], node, xmllangstack[0], errorHandler);
-
-                    estack[0].contents.push(p);
-
-                    estack.unshift(p);
-
-                } else if (node.local === 'span') {
-
-                    if (!(estack[0] instanceof Span || estack[0] instanceof P)) {
-
-                        reportFatal(errorHandler, "Parent of <span> element is not <span> or <p> at " + this.line + "," + this.column + ")");
-
-                    }
-
-                    var ns = new Span();
-
-                    ns.initFromNode(doc, estack[0], node, xmllangstack[0], xmlspacestack[0], errorHandler);
-
-                    estack[0].contents.push(ns);
-
-                    estack.unshift(ns);
-
-                } else if (node.local === 'br') {
-
-                    if (!(estack[0] instanceof Span || estack[0] instanceof P)) {
-
-                        reportFatal(errorHandler, "Parent of <br> element is not <span> or <p> at " + this.line + "," + this.column + ")");
-
-                    }
-
-                    var nb = new Br();
-
-                    nb.initFromNode(doc, estack[0], node, xmllangstack[0], errorHandler);
-
-                    estack[0].contents.push(nb);
-
-                    estack.unshift(nb);
-
-                } else if (node.local === 'set') {
-
-                    if (!(estack[0] instanceof Span ||
-                            estack[0] instanceof P ||
-                            estack[0] instanceof Div ||
-                            estack[0] instanceof Body ||
-                            estack[0] instanceof Region ||
-                            estack[0] instanceof Br)) {
-
-                        reportFatal(errorHandler, "Parent of <set> element is not a content element or a region at " + this.line + "," + this.column + ")");
-
-                    }
-
-                    var st = new Set();
-
-                    st.initFromNode(doc, estack[0], node, errorHandler);
-
-                    estack[0].sets.push(st);
-
-                    estack.unshift(st);
-
-                } else {
-
-                    /* element in the TT namespace, but not a content element */
-
-                    estack.unshift(new ForeignElement(node));
                 }
+
+                estack[0].contents = cs;
+
+            }
+
+            // remove redundant nested anonymous spans (9.3.3(1)(c))
+
+            if (estack[0] instanceof Span &&
+                estack[0].contents.length === 1 &&
+                estack[0].contents[0] instanceof AnonymousSpan) {
+
+                estack[0].text = estack[0].contents[0].text;
+                delete estack[0].contents;
+
+            }
+
+        } else if (estack[0] instanceof ForeignElement) {
+
+            if (estack[0].node.uri === imscNames.ns_tt &&
+                estack[0].node.local === 'metadata') {
+
+                /* leave the metadata element */
+
+                metadata_depth--;
+
+            } else if (metadata_depth > 0 &&
+                metadataHandler &&
+                'onCloseTag' in metadataHandler) {
+
+                /* end of child of metadata element */
+
+                metadataHandler.onCloseTag();
+
+            }
+
+        }
+
+        // TODO: delete stylerefs?
+
+        // maintain the xml:space stack
+
+        xmlspacestack.shift();
+
+        // maintain the xml:lang stack
+
+        xmllangstack.shift();
+
+        // prepare for the next element
+
+        estack.shift();
+    };
+
+    p.ontext = function (str) {
+
+        if (estack[0] === undefined) {
+
+            /* ignoring text outside of elements */
+
+        } else if (estack[0] instanceof Span || estack[0] instanceof P) {
+
+            /* ignore children text nodes in ruby container spans */
+
+            if (estack[0] instanceof Span) {
+
+                var ruby = estack[0].styleAttrs[imscStyles.byName.ruby.qname];
+
+                if (ruby === 'container' || ruby === 'textContainer' || ruby === 'baseContainer') {
+
+                    return;
+
+                }
+
+            }
+
+            /* create an anonymous span */
+
+            var s = new AnonymousSpan();
+
+            s.initFromText(doc, estack[0], str, xmllangstack[0], xmlspacestack[0], errorHandler);
+
+            estack[0].contents.push(s);
+
+        } else if (estack[0] instanceof ForeignElement &&
+            metadata_depth > 0 &&
+            metadataHandler &&
+            'onText' in metadataHandler) {
+
+            /* text node within a child of metadata element */
+
+            metadataHandler.onText(str);
+
+        }
+
+    };
+
+
+    p.onopentag = function (node) {
+
+        // maintain the xml:space stack
+
+        var xmlspace = node.attributes['xml:space'];
+
+        if (xmlspace) {
+
+            xmlspacestack.unshift(xmlspace.value);
+
+        } else {
+
+            if (xmlspacestack.length === 0) {
+
+                xmlspacestack.unshift('default');
 
             } else {
 
-                /* ignore elements not in the TTML namespace unless in metadata element */
+                xmlspacestack.unshift(xmlspacestack[0]);
+
+            }
+
+        }
+
+        /* maintain the xml:lang stack */
+
+
+        var xmllang = node.attributes['xml:lang'];
+
+        if (xmllang) {
+
+            xmllangstack.unshift(xmllang.value);
+
+        } else {
+
+            if (xmllangstack.length === 0) {
+
+                xmllangstack.unshift('');
+
+            } else {
+
+                xmllangstack.unshift(xmllangstack[0]);
+
+            }
+
+        }
+
+
+        /* process the element */
+
+        if (node.uri === imscNames.ns_tt) {
+
+            if (node.local === 'tt') {
+
+                if (doc !== null) {
+
+                    reportFatal(errorHandler, 'Two <tt> elements at (' + this.line + ',' + this.column + ')');
+
+                }
+
+                doc = new TT();
+
+                doc.initFromNode(node, xmllangstack[0], errorHandler);
+
+                estack.unshift(doc);
+
+            } else if (node.local === 'head') {
+
+                if (!(estack[0] instanceof TT)) {
+                    reportFatal(errorHandler, 'Parent of <head> element is not <tt> at (' + this.line + ',' + this.column + ')');
+                }
+
+                estack.unshift(doc.head);
+
+            } else if (node.local === 'styling') {
+
+                if (!(estack[0] instanceof Head)) {
+                    reportFatal(errorHandler, 'Parent of <styling> element is not <head> at (' + this.line + ',' + this.column + ')');
+                }
+
+                estack.unshift(doc.head.styling);
+
+            } else if (node.local === 'style') {
+
+                var s;
+
+                if (estack[0] instanceof Styling) {
+
+                    s = new Style();
+
+                    s.initFromNode(node, errorHandler);
+
+                    /* ignore <style> element missing @id */
+
+                    if (!s.id) {
+
+                        reportError(errorHandler, '<style> element missing "id" attribute');
+
+                    } else {
+
+                        doc.head.styling.styles[s.id] = s;
+
+                    }
+
+                    estack.unshift(s);
+
+                } else if (estack[0] instanceof Region) {
+
+                    /* nested styles can be merged with specified styles
+                     * immediately, with lower priority
+                     * (see 8.4.4.2(3) at TTML1 )
+                     */
+
+                    s = new Style();
+
+                    s.initFromNode(node, errorHandler);
+
+                    mergeStylesIfNotPresent(s.styleAttrs, estack[0].styleAttrs);
+
+                    estack.unshift(s);
+
+                } else {
+
+                    reportFatal(errorHandler, 'Parent of <style> element is not <styling> or <region> at (' + this.line + ',' + this.column + ')');
+
+                }
+
+            } else if (node.local === 'initial') {
+
+                var ini;
+
+                if (estack[0] instanceof Styling) {
+
+                    ini = new Initial();
+
+                    ini.initFromNode(node, errorHandler);
+
+                    for (var qn in ini.styleAttrs) {
+
+                        if (!imscUtils.checkHasOwnProperty(ini.styleAttrs, qn)) continue;
+
+                        doc.head.styling.initials[qn] = ini.styleAttrs[qn];
+
+                    }
+
+                    estack.unshift(ini);
+
+                } else {
+
+                    reportFatal(errorHandler, 'Parent of <initial> element is not <styling> at (' + this.line + ',' + this.column + ')');
+
+                }
+
+            } else if (node.local === 'layout') {
+
+                if (!(estack[0] instanceof Head)) {
+
+                    reportFatal(errorHandler, 'Parent of <layout> element is not <head> at ' + this.line + ',' + this.column + ')');
+
+                }
+
+                estack.unshift(doc.head.layout);
+
+            } else if (node.local === 'region') {
+
+                if (!(estack[0] instanceof Layout)) {
+                    reportFatal(errorHandler, 'Parent of <region> element is not <layout> at ' + this.line + ',' + this.column + ')');
+                }
+
+                var r = new Region();
+
+                r.initFromNode(doc, node, xmllangstack[0], errorHandler);
+
+                if (!r.id || r.id in doc.head.layout.regions) {
+
+                    reportError(errorHandler, 'Ignoring <region> with duplicate or missing @id at ' + this.line + ',' + this.column + ')');
+
+                } else {
+
+                    doc.head.layout.regions[r.id] = r;
+
+                }
+
+                estack.unshift(r);
+
+            } else if (node.local === 'body') {
+
+                if (!(estack[0] instanceof TT)) {
+
+                    reportFatal(errorHandler, 'Parent of <body> element is not <tt> at ' + this.line + ',' + this.column + ')');
+
+                }
+
+                if (doc.body !== null) {
+
+                    reportFatal(errorHandler, 'Second <body> element at ' + this.line + ',' + this.column + ')');
+
+                }
+
+                var b = new Body();
+
+                b.initFromNode(doc, node, xmllangstack[0], errorHandler);
+
+                doc.body = b;
+
+                estack.unshift(b);
+
+            } else if (node.local === 'div') {
+
+                if (!(estack[0] instanceof Div || estack[0] instanceof Body)) {
+
+                    reportFatal(errorHandler, 'Parent of <div> element is not <body> or <div> at ' + this.line + ',' + this.column + ')');
+
+                }
+
+                var d = new Div();
+
+                d.initFromNode(doc, estack[0], node, xmllangstack[0], errorHandler);
+
+                /* transform smpte:backgroundImage to TTML2 image element */
+
+                var bi = d.styleAttrs[imscStyles.byName.backgroundImage.qname];
+
+                if (bi) {
+                    d.contents.push(new Image(bi));
+                    delete d.styleAttrs[imscStyles.byName.backgroundImage.qname];
+                }
+
+                estack[0].contents.push(d);
+
+                estack.unshift(d);
+
+            } else if (node.local === 'image') {
+
+                if (!(estack[0] instanceof Div)) {
+
+                    reportFatal(errorHandler, 'Parent of <image> element is not <div> at ' + this.line + ',' + this.column + ')');
+
+                }
+
+                var img = new Image();
+
+                img.initFromNode(doc, estack[0], node, xmllangstack[0], errorHandler);
+
+                estack[0].contents.push(img);
+
+                estack.unshift(img);
+
+            } else if (node.local === 'p') {
+
+                if (!(estack[0] instanceof Div)) {
+
+                    reportFatal(errorHandler, 'Parent of <p> element is not <div> at ' + this.line + ',' + this.column + ')');
+
+                }
+
+                var p = new P();
+
+                p.initFromNode(doc, estack[0], node, xmllangstack[0], errorHandler);
+
+                estack[0].contents.push(p);
+
+                estack.unshift(p);
+
+            } else if (node.local === 'span') {
+
+                if (!(estack[0] instanceof Span || estack[0] instanceof P)) {
+
+                    reportFatal(errorHandler, 'Parent of <span> element is not <span> or <p> at ' + this.line + ',' + this.column + ')');
+
+                }
+
+                var ns = new Span();
+
+                ns.initFromNode(doc, estack[0], node, xmllangstack[0], xmlspacestack[0], errorHandler);
+
+                estack[0].contents.push(ns);
+
+                estack.unshift(ns);
+
+            } else if (node.local === 'br') {
+
+                if (!(estack[0] instanceof Span || estack[0] instanceof P)) {
+
+                    reportFatal(errorHandler, 'Parent of <br> element is not <span> or <p> at ' + this.line + ',' + this.column + ')');
+
+                }
+
+                var nb = new Br();
+
+                nb.initFromNode(doc, estack[0], node, xmllangstack[0], errorHandler);
+
+                estack[0].contents.push(nb);
+
+                estack.unshift(nb);
+
+            } else if (node.local === 'set') {
+
+                if (!(estack[0] instanceof Span ||
+                    estack[0] instanceof P ||
+                    estack[0] instanceof Div ||
+                    estack[0] instanceof Body ||
+                    estack[0] instanceof Region ||
+                    estack[0] instanceof Br)) {
+
+                    reportFatal(errorHandler, 'Parent of <set> element is not a content element or a region at ' + this.line + ',' + this.column + ')');
+
+                }
+
+                var st = new Set();
+
+                st.initFromNode(doc, estack[0], node, errorHandler);
+
+                estack[0].sets.push(st);
+
+                estack.unshift(st);
+
+            } else {
+
+                /* element in the TT namespace, but not a content element */
 
                 estack.unshift(new ForeignElement(node));
-
             }
 
-            /* handle metadata callbacks */
+        } else {
 
-            if (estack[0] instanceof ForeignElement) {
+            /* ignore elements not in the TTML namespace unless in metadata element */
 
-                if (node.uri === imscNames.ns_tt &&
-                        node.local === 'metadata') {
+            estack.unshift(new ForeignElement(node));
 
-                    /* enter the metadata element */
+        }
 
-                    metadata_depth++;
+        /* handle metadata callbacks */
 
-                } else if (
-                        metadata_depth > 0 &&
-                        metadataHandler &&
-                        'onOpenTag' in metadataHandler
-                        ) {
+        if (estack[0] instanceof ForeignElement) {
 
-                    /* start of child of metadata element */
+            if (node.uri === imscNames.ns_tt &&
+                node.local === 'metadata') {
 
-                    var attrs = [];
+                /* enter the metadata element */
 
-                    for (var a in node.attributes) {
-                        attrs[node.attributes[a].uri + " " + node.attributes[a].local] =
-                                {
-                                    uri: node.attributes[a].uri,
-                                    local: node.attributes[a].local,
-                                    value: node.attributes[a].value
-                                };
-                    }
+                metadata_depth++;
 
-                    metadataHandler.onOpenTag(node.uri, node.local, attrs);
+            } else if (
+                metadata_depth > 0 &&
+                metadataHandler &&
+                'onOpenTag' in metadataHandler
+            ) {
 
+                /* start of child of metadata element */
+
+                var attrs = [];
+
+                for (var a in node.attributes) {
+                    attrs[node.attributes[a].uri + ' ' + node.attributes[a].local] =
+                        {
+                            uri: node.attributes[a].uri,
+                            local: node.attributes[a].local,
+                            value: node.attributes[a].value
+                        };
                 }
 
-            }
+                metadataHandler.onOpenTag(node.uri, node.local, attrs);
 
-        };
-
-        // parse the document
-
-        p.write(xmlstring).close();
-
-        // all referential styling has been flatten, so delete styles
-
-        delete doc.head.styling.styles;
-       
-        // create default region if no regions specified
-
-        var hasRegions = false;
-
-        /* AFAIK the only way to determine whether an object has members */
-
-        for (var i in doc.head.layout.regions) {
-
-            if (doc.head.layout.regions.hasOwnProperty(i)) {
-                hasRegions = true;
-                break;
             }
 
         }
 
-        if (!hasRegions) {
-
-            /* create default region */
-
-            var dr = Region.prototype.createDefaultRegion(doc.lang);
-
-            doc.head.layout.regions[dr.id] = dr;
-
-        }
-
-        /* resolve desired timing for regions */
-
-        for (var region_i in doc.head.layout.regions) {
-
-            if (! doc.head.layout.regions.hasOwnProperty(region_i)) continue;
-
-            resolveTiming(doc, doc.head.layout.regions[region_i], null, null);
-
-        }
-
-        /* resolve desired timing for content elements */
-
-        if (doc.body) {
-            resolveTiming(doc, doc.body, null, null);
-        }
-
-        /* remove undefined spans in ruby containers */
-
-        if (doc.body) {
-            cleanRubyContainers(doc.body);
-        }
-
-        return doc;
     };
 
-    function cleanRubyContainers(element) {
-        
-        if (! ('contents' in element)) return;
+    // parse the document
 
-        var rubyval = 'styleAttrs' in element ? element.styleAttrs[imscStyles.byName.ruby.qname] : null;
+    p.write(xmlstring).close();
 
-        var isrubycontainer = (element.kind === 'span' && (rubyval === "container" || rubyval === "textContainer" || rubyval === "baseContainer"));
+    // all referential styling has been flatten, so delete styles
 
-        for (var i = element.contents.length - 1; i >= 0; i--) {
+    delete doc.head.styling.styles;
 
-            if (isrubycontainer && !('styleAttrs' in element.contents[i] && imscStyles.byName.ruby.qname in element.contents[i].styleAttrs)) {
+    // create default region if no regions specified
 
-                /* prune undefined <span> in ruby containers */
+    var hasRegions = false;
 
-                delete element.contents[i];
+    /* AFAIK the only way to determine whether an object has members */
 
-            } else {
+    for (var i in doc.head.layout.regions) {
 
-                cleanRubyContainers(element.contents[i]);
+        if (imscUtils.checkHasOwnProperty(doc.head.layout.regions, i)) {
+            hasRegions = true;
+            break;
+        }
 
-            }
+    }
+
+    if (!hasRegions) {
+
+        /* create default region */
+
+        var dr = Region.prototype.createDefaultRegion(doc.lang);
+
+        doc.head.layout.regions[dr.id] = dr;
+
+    }
+
+    /* resolve desired timing for regions */
+
+    for (var region_i in doc.head.layout.regions) {
+
+        if (!imscUtils.checkHasOwnProperty(doc.head.layout.regions, region_i)) continue;
+
+        resolveTiming(doc, doc.head.layout.regions[region_i], null, null);
+
+    }
+
+    /* resolve desired timing for content elements */
+
+    if (doc.body) {
+        resolveTiming(doc, doc.body, null, null);
+    }
+
+    /* remove undefined spans in ruby containers */
+
+    if (doc.body) {
+        cleanRubyContainers(doc.body);
+    }
+
+    return doc;
+};
+
+function cleanRubyContainers(element) {
+
+    if (!('contents' in element)) return;
+
+    var rubyval = 'styleAttrs' in element ? element.styleAttrs[imscStyles.byName.ruby.qname] : null;
+
+    var isrubycontainer = (element.kind === 'span' && (rubyval === 'container' || rubyval === 'textContainer' || rubyval === 'baseContainer'));
+
+    for (var i = element.contents.length - 1; i >= 0; i--) {
+
+        if (isrubycontainer && !('styleAttrs' in element.contents[i] && imscStyles.byName.ruby.qname in element.contents[i].styleAttrs)) {
+
+            /* prune undefined <span> in ruby containers */
+
+            delete element.contents[i];
+
+        } else {
+
+            cleanRubyContainers(element.contents[i]);
 
         }
 
     }
 
-    function resolveTiming(doc, element, prev_sibling, parent) {
+}
 
-        /* are we in a seq container? */
+function resolveTiming(doc, element, prev_sibling, parent) {
 
-        var isinseq = parent && parent.timeContainer === "seq";
+    /* are we in a seq container? */
 
-        /* determine implicit begin */
+    var isinseq = parent && parent.timeContainer === 'seq';
 
-        var implicit_begin = 0; /* default */
+    /* determine implicit begin */
 
-        if (parent) {
+    var implicit_begin = 0; /* default */
 
-            if (isinseq && prev_sibling) {
+    if (parent) {
 
-                /*
-                 * if seq time container, offset from the previous sibling end
-                 */
+        if (isinseq && prev_sibling) {
 
-                implicit_begin = prev_sibling.end;
+            /*
+             * if seq time container, offset from the previous sibling end
+             */
+
+            implicit_begin = prev_sibling.end;
 
 
-            } else {
+        } else {
 
-                implicit_begin = parent.begin;
-
-            }
+            implicit_begin = parent.begin;
 
         }
 
-        /* compute desired begin */
+    }
 
-        element.begin = element.explicit_begin ? element.explicit_begin + implicit_begin : implicit_begin;
+    /* compute desired begin */
+
+    element.begin = element.explicit_begin ? element.explicit_begin + implicit_begin : implicit_begin;
 
 
-        /* determine implicit end */
+    /* determine implicit end */
 
-        var implicit_end = element.begin;
+    var implicit_end = element.begin;
 
-        var s = null;
+    var s = null;
 
-        if ("sets" in element) {
+    if ('sets' in element) {
 
-            for (var set_i = 0; set_i < element.sets.length; set_i++) {
+        for (var set_i = 0; set_i < element.sets.length; set_i++) {
 
-                resolveTiming(doc, element.sets[set_i], s, element);
+            resolveTiming(doc, element.sets[set_i], s, element);
 
-                if (element.timeContainer === "seq") {
+            if (element.timeContainer === 'seq') {
 
-                    implicit_end = element.sets[set_i].end;
+                implicit_end = element.sets[set_i].end;
+
+            } else {
+
+                implicit_end = Math.max(implicit_end, element.sets[set_i].end);
+
+            }
+
+            s = element.sets[set_i];
+
+        }
+
+    }
+
+    if (!('contents' in element)) {
+
+        /* anonymous spans and regions and <set> and <br>s and spans with only children text nodes */
+
+        if (isinseq) {
+
+            /* in seq container, implicit duration is zero */
+
+            implicit_end = element.begin;
+
+        } else {
+
+            /* in par container, implicit duration is indefinite */
+
+            implicit_end = Number.POSITIVE_INFINITY;
+
+        }
+
+    } else if ('contents' in element) {
+
+        for (var content_i = 0; content_i < element.contents.length; content_i++) {
+
+            resolveTiming(doc, element.contents[content_i], s, element);
+
+            if (element.timeContainer === 'seq') {
+
+                implicit_end = element.contents[content_i].end;
+
+            } else {
+
+                implicit_end = Math.max(implicit_end, element.contents[content_i].end);
+
+            }
+
+            s = element.contents[content_i];
+
+        }
+
+    }
+
+    /* determine desired end */
+    /* it is never made really clear in SMIL that the explicit end is offset by the implicit begin */
+
+    if (element.explicit_end !== null && element.explicit_dur !== null) {
+
+        element.end = Math.min(element.begin + element.explicit_dur, implicit_begin + element.explicit_end);
+
+    } else if (element.explicit_end === null && element.explicit_dur !== null) {
+
+        element.end = element.begin + element.explicit_dur;
+
+    } else if (element.explicit_end !== null && element.explicit_dur === null) {
+
+        element.end = implicit_begin + element.explicit_end;
+
+    } else {
+
+        element.end = implicit_end;
+    }
+
+    delete element.explicit_begin;
+    delete element.explicit_dur;
+    delete element.explicit_end;
+
+    doc._registerEvent(element);
+
+}
+
+function ForeignElement(node) {
+    this.node = node;
+}
+
+function TT() {
+    this.events = [];
+    this.head = new Head();
+    this.body = null;
+}
+
+TT.prototype.initFromNode = function (node, xmllang, errorHandler) {
+
+    /* compute cell resolution */
+
+    var cr = extractCellResolution(node, errorHandler);
+
+    this.cellLength = {
+        'h': new imscUtils.ComputedLength(0, 1 / cr.h),
+        'w': new imscUtils.ComputedLength(1 / cr.w, 0)
+    };
+
+    /* extract frame rate and tick rate */
+
+    var frtr = extractFrameAndTickRate(node, errorHandler);
+
+    this.effectiveFrameRate = frtr.effectiveFrameRate;
+
+    this.tickRate = frtr.tickRate;
+
+    /* extract aspect ratio */
+
+    this.aspectRatio = extractAspectRatio(node, errorHandler);
+
+    /* check timebase */
+
+    var attr = findAttribute(node, imscNames.ns_ttp, 'timeBase');
+
+    if (attr !== null && attr !== 'media') {
+
+        reportFatal(errorHandler, 'Unsupported time base');
+
+    }
+
+    /* retrieve extent */
+
+    var e = extractExtent(node, errorHandler);
+
+    if (e === null) {
+
+        this.pxLength = {
+            'h': null,
+            'w': null
+        };
+
+    } else {
+
+        if (e.h.unit !== 'px' || e.w.unit !== 'px') {
+            reportFatal(errorHandler, 'Extent on TT must be in px or absent');
+        }
+
+        this.pxLength = {
+            'h': new imscUtils.ComputedLength(0, 1 / e.h.value),
+            'w': new imscUtils.ComputedLength(1 / e.w.value, 0)
+        };
+    }
+
+    /** set root container dimensions to (1, 1) arbitrarily
+     * the root container is mapped to actual dimensions at rendering
+     **/
+
+    this.dimensions = {
+        'h': new imscUtils.ComputedLength(0, 1),
+        'w': new imscUtils.ComputedLength(1, 0)
+
+    };
+
+    /* xml:lang */
+
+    this.lang = xmllang;
+
+};
+
+/* register a temporal events */
+TT.prototype._registerEvent = function (elem) {
+
+    /* skip if begin is not < then end */
+
+    if (elem.end <= elem.begin)
+        return;
+
+    /* index the begin time of the event */
+
+    var b_i = indexOf(this.events, elem.begin);
+
+    if (!b_i.found) {
+        this.events.splice(b_i.index, 0, elem.begin);
+    }
+
+    /* index the end time of the event */
+
+    if (elem.end !== Number.POSITIVE_INFINITY) {
+
+        var e_i = indexOf(this.events, elem.end);
+
+        if (!e_i.found) {
+            this.events.splice(e_i.index, 0, elem.end);
+        }
+
+    }
+
+};
+
+
+/*
+ * Retrieves the range of ISD times covered by the document
+ *
+ * @returns {Array} Array of two elements: min_begin_time and max_begin_time
+ *
+ */
+TT.prototype.getMediaTimeRange = function () {
+
+    return [this.events[0], this.events[this.events.length - 1]];
+};
+
+/*
+ * Returns list of ISD begin times
+ *
+ * @returns {Array}
+ */
+TT.prototype.getMediaTimeEvents = function () {
+
+    return this.events;
+};
+
+/*
+ * Represents a TTML Head element
+ */
+
+function Head() {
+    this.styling = new Styling();
+    this.layout = new Layout();
+}
+
+/*
+ * Represents a TTML Styling element
+ */
+
+function Styling() {
+    this.styles = {};
+    this.initials = {};
+}
+
+/*
+ * Represents a TTML Style element
+ */
+
+function Style() {
+    this.id = null;
+    this.styleAttrs = null;
+    this.styleRefs = null;
+}
+
+Style.prototype.initFromNode = function (node, errorHandler) {
+    this.id = elementGetXMLID(node);
+    this.styleAttrs = elementGetStyles(node, errorHandler);
+    this.styleRefs = elementGetStyleRefs(node);
+};
+
+/*
+ * Represents a TTML initial element
+ */
+
+function Initial() {
+    this.styleAttrs = null;
+}
+
+Initial.prototype.initFromNode = function (node) {
+
+    this.styleAttrs = {};
+
+    for (var i in node.attributes) {
+
+        if (node.attributes[i].uri === imscNames.ns_itts ||
+            node.attributes[i].uri === imscNames.ns_ebutts ||
+            node.attributes[i].uri === imscNames.ns_tts) {
+
+            var qname = node.attributes[i].uri + ' ' + node.attributes[i].local;
+
+            this.styleAttrs[qname] = node.attributes[i].value;
+
+        }
+    }
+
+};
+
+/*
+ * Represents a TTML Layout element
+ *
+ */
+
+function Layout() {
+    this.regions = {};
+}
+
+/*
+ * Represents a TTML image element
+ */
+
+function Image(src, type) {
+    ContentElement.call(this, 'image');
+    this.src = src;
+    this.type = type;
+}
+
+Image.prototype.initFromNode = function (doc, parent, node, xmllang, errorHandler) {
+    this.src = 'src' in node.attributes ? node.attributes.src.value : null;
+
+    if (!this.src) {
+        reportError(errorHandler, 'Invalid image@src attribute');
+    }
+
+    this.type = 'type' in node.attributes ? node.attributes.type.value : null;
+
+    if (!this.type) {
+        reportError(errorHandler, 'Invalid image@type attribute');
+    }
+
+    StyledElement.prototype.initFromNode.call(this, doc, parent, node, errorHandler);
+    TimedElement.prototype.initFromNode.call(this, doc, parent, node, errorHandler);
+    AnimatedElement.prototype.initFromNode.call(this, doc, parent, node, errorHandler);
+    LayoutElement.prototype.initFromNode.call(this, doc, parent, node, errorHandler);
+
+    this.lang = xmllang;
+};
+
+/*
+ * TTML element utility functions
+ *
+ */
+
+function ContentElement(kind) {
+    this.kind = kind;
+}
+
+function IdentifiedElement(id) {
+    this.id = id;
+}
+
+IdentifiedElement.prototype.initFromNode = function (doc, parent, node) {
+    this.id = elementGetXMLID(node);
+};
+
+function LayoutElement(id) {
+    this.regionID = id;
+}
+
+LayoutElement.prototype.initFromNode = function (doc, parent, node) {
+    this.regionID = elementGetRegionID(node);
+};
+
+function StyledElement(styleAttrs) {
+    this.styleAttrs = styleAttrs;
+}
+
+StyledElement.prototype.initFromNode = function (doc, parent, node, errorHandler) {
+
+    this.styleAttrs = elementGetStyles(node, errorHandler);
+
+    if (doc.head !== null && doc.head.styling !== null) {
+        mergeReferencedStyles(doc.head.styling, elementGetStyleRefs(node), this.styleAttrs, errorHandler);
+    }
+
+};
+
+function AnimatedElement(sets) {
+    this.sets = sets;
+}
+
+AnimatedElement.prototype.initFromNode = function () { // function (doc, parent, node, errorHandler) {
+    this.sets = [];
+};
+
+function ContainerElement(contents) {
+    this.contents = contents;
+}
+
+ContainerElement.prototype.initFromNode = function () { // function (doc, parent, node, errorHandler) {
+    this.contents = [];
+};
+
+function TimedElement(explicit_begin, explicit_end, explicit_dur) {
+    this.explicit_begin = explicit_begin;
+    this.explicit_end = explicit_end;
+    this.explicit_dur = explicit_dur;
+}
+
+TimedElement.prototype.initFromNode = function (doc, parent, node, errorHandler) {
+    var t = processTiming(doc, parent, node, errorHandler);
+    this.explicit_begin = t.explicit_begin;
+    this.explicit_end = t.explicit_end;
+    this.explicit_dur = t.explicit_dur;
+
+    this.timeContainer = elementGetTimeContainer(node, errorHandler);
+};
+
+
+/*
+ * Represents a TTML body element
+ */
+
+
+function Body() {
+    ContentElement.call(this, 'body');
+}
+
+
+Body.prototype.initFromNode = function (doc, node, xmllang, errorHandler) {
+    StyledElement.prototype.initFromNode.call(this, doc, null, node, errorHandler);
+    TimedElement.prototype.initFromNode.call(this, doc, null, node, errorHandler);
+    AnimatedElement.prototype.initFromNode.call(this, doc, null, node, errorHandler);
+    LayoutElement.prototype.initFromNode.call(this, doc, null, node, errorHandler);
+    ContainerElement.prototype.initFromNode.call(this, doc, null, node, errorHandler);
+
+    this.lang = xmllang;
+};
+
+/*
+ * Represents a TTML div element
+ */
+
+function Div() {
+    ContentElement.call(this, 'div');
+}
+
+Div.prototype.initFromNode = function (doc, parent, node, xmllang, errorHandler) {
+    StyledElement.prototype.initFromNode.call(this, doc, parent, node, errorHandler);
+    TimedElement.prototype.initFromNode.call(this, doc, parent, node, errorHandler);
+    AnimatedElement.prototype.initFromNode.call(this, doc, parent, node, errorHandler);
+    LayoutElement.prototype.initFromNode.call(this, doc, parent, node, errorHandler);
+    ContainerElement.prototype.initFromNode.call(this, doc, parent, node, errorHandler);
+
+    this.lang = xmllang;
+};
+
+/*
+ * Represents a TTML p element
+ */
+
+function P() {
+    ContentElement.call(this, 'p');
+}
+
+P.prototype.initFromNode = function (doc, parent, node, xmllang, errorHandler) {
+    StyledElement.prototype.initFromNode.call(this, doc, parent, node, errorHandler);
+    TimedElement.prototype.initFromNode.call(this, doc, parent, node, errorHandler);
+    AnimatedElement.prototype.initFromNode.call(this, doc, parent, node, errorHandler);
+    LayoutElement.prototype.initFromNode.call(this, doc, parent, node, errorHandler);
+    ContainerElement.prototype.initFromNode.call(this, doc, parent, node, errorHandler);
+
+    this.lang = xmllang;
+};
+
+/*
+ * Represents a TTML span element
+ */
+
+function Span() {
+    ContentElement.call(this, 'span');
+}
+
+Span.prototype.initFromNode = function (doc, parent, node, xmllang, xmlspace, errorHandler) {
+    StyledElement.prototype.initFromNode.call(this, doc, parent, node, errorHandler);
+    TimedElement.prototype.initFromNode.call(this, doc, parent, node, errorHandler);
+    AnimatedElement.prototype.initFromNode.call(this, doc, parent, node, errorHandler);
+    LayoutElement.prototype.initFromNode.call(this, doc, parent, node, errorHandler);
+    ContainerElement.prototype.initFromNode.call(this, doc, parent, node, errorHandler);
+
+    this.space = xmlspace;
+    this.lang = xmllang;
+};
+
+/*
+ * Represents a TTML anonymous span element
+ */
+
+function AnonymousSpan() {
+    ContentElement.call(this, 'span');
+}
+
+AnonymousSpan.prototype.initFromText = function (doc, parent, text, xmllang, xmlspace, errorHandler) {
+    TimedElement.prototype.initFromNode.call(this, doc, parent, null, errorHandler);
+
+    this.text = text;
+    this.space = xmlspace;
+    this.lang = xmllang;
+};
+
+/*
+ * Represents a TTML br element
+ */
+
+function Br() {
+    ContentElement.call(this, 'br');
+}
+
+Br.prototype.initFromNode = function (doc, parent, node, xmllang, errorHandler) {
+    LayoutElement.prototype.initFromNode.call(this, doc, parent, node, errorHandler);
+    TimedElement.prototype.initFromNode.call(this, doc, parent, node, errorHandler);
+
+    this.lang = xmllang;
+};
+
+/*
+ * Represents a TTML Region element
+ *
+ */
+
+function Region() {
+}
+
+Region.prototype.createDefaultRegion = function (xmllang) {
+    var r = new Region();
+
+    IdentifiedElement.call(r, '');
+    StyledElement.call(r, {});
+    AnimatedElement.call(r, []);
+    TimedElement.call(r, 0, Number.POSITIVE_INFINITY, null);
+
+    this.lang = xmllang;
+
+    return r;
+};
+
+Region.prototype.initFromNode = function (doc, node, xmllang, errorHandler) {
+    IdentifiedElement.prototype.initFromNode.call(this, doc, null, node, errorHandler);
+    TimedElement.prototype.initFromNode.call(this, doc, null, node, errorHandler);
+    AnimatedElement.prototype.initFromNode.call(this, doc, null, node, errorHandler);
+
+    /* add specified styles */
+
+    this.styleAttrs = elementGetStyles(node, errorHandler);
+
+    /* remember referential styles for merging after nested styling is processed*/
+
+    this.styleRefs = elementGetStyleRefs(node);
+
+    /* xml:lang */
+
+    this.lang = xmllang;
+};
+
+/*
+ * Represents a TTML Set element
+ *
+ */
+
+function Set() {
+}
+
+Set.prototype.initFromNode = function (doc, parent, node, errorHandler) {
+
+    TimedElement.prototype.initFromNode.call(this, doc, parent, node, errorHandler);
+
+    var styles = elementGetStyles(node, errorHandler);
+
+    this.qname = null;
+    this.value = null;
+
+    for (var qname in styles) {
+
+        if (!imscUtils.checkHasOwnProperty(styles, qname)) continue;
+
+        if (this.qname) {
+
+            reportError(errorHandler, 'More than one style specified on set');
+            break;
+
+        }
+
+        this.qname = qname;
+        this.value = styles[qname];
+
+    }
+
+};
+
+/*
+ * Utility functions
+ *
+ */
+
+
+function elementGetXMLID(node) {
+    return node && 'xml:id' in node.attributes ? node.attributes['xml:id'].value || null : null;
+}
+
+function elementGetRegionID(node) {
+    return node && 'region' in node.attributes ? node.attributes.region.value : '';
+}
+
+function elementGetTimeContainer(node, errorHandler) {
+
+    var tc = node && 'timeContainer' in node.attributes ? node.attributes.timeContainer.value : null;
+
+    if ((!tc) || tc === 'par') {
+
+        return 'par';
+
+    } else if (tc === 'seq') {
+
+        return 'seq';
+
+    } else {
+
+        reportError(errorHandler, 'Illegal value of timeContainer (assuming \'par\')');
+
+        return 'par';
+
+    }
+
+}
+
+function elementGetStyleRefs(node) {
+
+    return node && 'style' in node.attributes ? node.attributes.style.value.split(' ') : [];
+
+}
+
+function elementGetStyles(node, errorHandler) {
+
+    var s = {};
+
+    if (node !== null) {
+
+        for (var i in node.attributes) {
+
+            var qname = node.attributes[i].uri + ' ' + node.attributes[i].local;
+
+            var sa = imscStyles.byQName[qname];
+
+            if (sa !== undefined) {
+
+                var val = sa.parse(node.attributes[i].value);
+
+                if (val !== null) {
+
+                    s[qname] = val;
+
+                    /* TODO: consider refactoring errorHandler into parse and compute routines */
+
+                    if (sa === imscStyles.byName.zIndex) {
+                        reportWarning(errorHandler, 'zIndex attribute present but not used by IMSC1 since regions do not overlap');
+                    }
 
                 } else {
 
-                    implicit_end = Math.max(implicit_end, element.sets[set_i].end);
+                    reportError(errorHandler, 'Cannot parse styling attribute ' + qname + ' --> ' + node.attributes[i].value);
 
                 }
-
-                s = element.sets[set_i];
 
             }
 
         }
 
-        if (!('contents' in element)) {
+    }
 
-            /* anonymous spans and regions and <set> and <br>s and spans with only children text nodes */
+    return s;
+}
 
-            if (isinseq) {
+function findAttribute(node, ns, name) {
+    for (var i in node.attributes) {
 
-                /* in seq container, implicit duration is zero */
+        if (node.attributes[i].uri === ns &&
+            node.attributes[i].local === name) {
 
-                implicit_end = element.begin;
+            return node.attributes[i].value;
+        }
+    }
+
+    return null;
+}
+
+function extractAspectRatio(node, errorHandler) {
+
+    var ar = findAttribute(node, imscNames.ns_ittp, 'aspectRatio');
+
+    if (ar === null) {
+
+        ar = findAttribute(node, imscNames.ns_ttp, 'displayAspectRatio');
+
+    }
+
+    var rslt = null;
+
+    if (ar !== null) {
+
+        var ASPECT_RATIO_RE = /(\d+)\s+(\d+)/;
+
+        var m = ASPECT_RATIO_RE.exec(ar);
+
+        if (m !== null) {
+
+            var w = parseInt(m[1]);
+
+            var h = parseInt(m[2]);
+
+            if (w !== 0 && h !== 0) {
+
+                rslt = w / h;
 
             } else {
 
-                /* in par container, implicit duration is indefinite */
-
-                implicit_end = Number.POSITIVE_INFINITY;
-
+                reportError(errorHandler, 'Illegal aspectRatio values (ignoring)');
             }
-
-        } else if ("contents" in element) {
- 
-            for (var content_i = 0; content_i < element.contents.length; content_i++) {
-
-                resolveTiming(doc, element.contents[content_i], s, element);
-
-                if (element.timeContainer === "seq") {
-
-                    implicit_end = element.contents[content_i].end;
-
-                } else {
-
-                    implicit_end = Math.max(implicit_end, element.contents[content_i].end);
-
-                }
-
-                s = element.contents[content_i];
-
-            }
-
-        }
-
-        /* determine desired end */
-        /* it is never made really clear in SMIL that the explicit end is offset by the implicit begin */
-
-        if (element.explicit_end !== null && element.explicit_dur !== null) {
-
-            element.end = Math.min(element.begin + element.explicit_dur, implicit_begin + element.explicit_end);
-
-        } else if (element.explicit_end === null && element.explicit_dur !== null) {
-
-            element.end = element.begin + element.explicit_dur;
-
-        } else if (element.explicit_end !== null && element.explicit_dur === null) {
-
-            element.end = implicit_begin + element.explicit_end;
 
         } else {
 
-            element.end = implicit_end;
+            reportError(errorHandler, 'Malformed aspectRatio attribute (ignoring)');
         }
 
-        delete element.explicit_begin;
-        delete element.explicit_dur;
-        delete element.explicit_end;
-
-        doc._registerEvent(element);
-
     }
 
-    function ForeignElement(node) {
-        this.node = node;
-    }
+    return rslt;
 
-    function TT() {
-        this.events = [];
-        this.head = new Head();
-        this.body = null;
-    }
+}
 
-    TT.prototype.initFromNode = function (node, xmllang, errorHandler) {
+/*
+ * Returns the cellResolution attribute from a node
+ *
+ */
+function extractCellResolution(node, errorHandler) {
 
-        /* compute cell resolution */
+    var cr = findAttribute(node, imscNames.ns_ttp, 'cellResolution');
 
-        var cr = extractCellResolution(node, errorHandler);
-        
-        this.cellLength = {
-                'h': new imscUtils.ComputedLength(0, 1/cr.h),
-                'w': new imscUtils.ComputedLength(1/cr.w, 0)
-            };
+    // initial value
 
-        /* extract frame rate and tick rate */
+    var h = 15;
+    var w = 32;
 
-        var frtr = extractFrameAndTickRate(node, errorHandler);
+    if (cr !== null) {
 
-        this.effectiveFrameRate = frtr.effectiveFrameRate;
+        var CELL_RESOLUTION_RE = /(\d+) (\d+)/;
 
-        this.tickRate = frtr.tickRate;
+        var m = CELL_RESOLUTION_RE.exec(cr);
 
-        /* extract aspect ratio */
+        if (m !== null) {
 
-        this.aspectRatio = extractAspectRatio(node, errorHandler);
+            w = parseInt(m[1]);
 
-        /* check timebase */
-
-        var attr = findAttribute(node, imscNames.ns_ttp, "timeBase");
-
-        if (attr !== null && attr !== "media") {
-
-            reportFatal(errorHandler, "Unsupported time base");
-
-        }
-
-        /* retrieve extent */
-
-        var e = extractExtent(node, errorHandler);
-
-        if (e === null) {
-
-            this.pxLength = {
-                'h': null,
-                'w': null
-            };
+            h = parseInt(m[2]);
 
         } else {
 
-            if (e.h.unit !== "px" || e.w.unit !== "px") {
-                reportFatal(errorHandler, "Extent on TT must be in px or absent");
-            }
-
-            this.pxLength = {
-                'h': new imscUtils.ComputedLength(0, 1 / e.h.value),
-                'w': new imscUtils.ComputedLength(1 / e.w.value, 0)
-            };
-        }
-        
-        /** set root container dimensions to (1, 1) arbitrarily
-          * the root container is mapped to actual dimensions at rendering
-        **/
-        
-        this.dimensions = {
-                'h': new imscUtils.ComputedLength(0, 1),
-                'w': new imscUtils.ComputedLength(1, 0)
-
-        };
-
-        /* xml:lang */
-
-        this.lang = xmllang;
-
-    };
-
-    /* register a temporal events */
-    TT.prototype._registerEvent = function (elem) {
-
-        /* skip if begin is not < then end */
-
-        if (elem.end <= elem.begin)
-            return;
-
-        /* index the begin time of the event */
-
-        var b_i = indexOf(this.events, elem.begin);
-
-        if (!b_i.found) {
-            this.events.splice(b_i.index, 0, elem.begin);
-        }
-
-        /* index the end time of the event */
-
-        if (elem.end !== Number.POSITIVE_INFINITY) {
-
-            var e_i = indexOf(this.events, elem.end);
-
-            if (!e_i.found) {
-                this.events.splice(e_i.index, 0, elem.end);
-            }
+            reportWarning(errorHandler, 'Malformed cellResolution value (using initial value instead)');
 
         }
 
-    };
-
-
-    /*
-     * Retrieves the range of ISD times covered by the document
-     * 
-     * @returns {Array} Array of two elements: min_begin_time and max_begin_time
-     * 
-     */
-    TT.prototype.getMediaTimeRange = function () {
-
-        return [this.events[0], this.events[this.events.length - 1]];
-    };
-
-    /*
-     * Returns list of ISD begin times  
-     * 
-     * @returns {Array}
-     */
-    TT.prototype.getMediaTimeEvents = function () {
-
-        return this.events;
-    };
-
-    /*
-     * Represents a TTML Head element
-     */
-
-    function Head() {
-        this.styling = new Styling();
-        this.layout = new Layout();
     }
 
-    /*
-     * Represents a TTML Styling element
-     */
+    return {'w': w, 'h': h};
 
-    function Styling() {
-        this.styles = {};
-        this.initials = {};
-    }
+}
 
-    /*
-     * Represents a TTML Style element
-     */
 
-    function Style() {
-        this.id = null;
-        this.styleAttrs = null;
-        this.styleRefs = null;
-    }
+function extractFrameAndTickRate(node, errorHandler) {
 
-    Style.prototype.initFromNode = function (node, errorHandler) {
-        this.id = elementGetXMLID(node);
-        this.styleAttrs = elementGetStyles(node, errorHandler);
-        this.styleRefs = elementGetStyleRefs(node);
-    };
-    
-    /*
-     * Represents a TTML initial element
-     */
+    // subFrameRate is ignored per IMSC1 specification
 
-    function Initial() {
-        this.styleAttrs = null;
-    }
+    // extract frame rate
 
-    Initial.prototype.initFromNode = function (node, errorHandler) {
-        
-        this.styleAttrs = {};
-        
-        for (var i in node.attributes) {
+    var fps_attr = findAttribute(node, imscNames.ns_ttp, 'frameRate');
 
-            if (node.attributes[i].uri === imscNames.ns_itts ||
-                node.attributes[i].uri === imscNames.ns_ebutts ||
-                node.attributes[i].uri === imscNames.ns_tts) {
-                
-                var qname = node.attributes[i].uri + " " + node.attributes[i].local;
-                
-                this.styleAttrs[qname] = node.attributes[i].value;
+    // initial value
 
-            }
-        }
-        
-    };
+    var fps = 30;
 
-    /*
-     * Represents a TTML Layout element
-     * 
-     */
+    // match variable
 
-    function Layout() {
-        this.regions = {};
-    }
-    
-    /*
-     * Represents a TTML image element
-     */
+    var m;
 
-    function Image(src, type) {
-        ContentElement.call(this, 'image');
-        this.src = src;
-        this.type = type;
-    }
+    if (fps_attr !== null) {
 
-    Image.prototype.initFromNode = function (doc, parent, node, xmllang, errorHandler) {
-        this.src = 'src' in node.attributes ? node.attributes.src.value : null;
-        
-        if (! this.src) {
-            reportError(errorHandler, "Invalid image@src attribute");
-        }
-        
-        this.type = 'type' in node.attributes ? node.attributes.type.value : null;
-        
-        if (! this.type) {
-            reportError(errorHandler, "Invalid image@type attribute");
-        }
-        
-        StyledElement.prototype.initFromNode.call(this, doc, parent, node, errorHandler);
-        TimedElement.prototype.initFromNode.call(this, doc, parent, node, errorHandler);
-        AnimatedElement.prototype.initFromNode.call(this, doc, parent, node, errorHandler);
-        LayoutElement.prototype.initFromNode.call(this, doc, parent, node, errorHandler);
+        var FRAME_RATE_RE = /(\d+)/;
 
-        this.lang = xmllang;
-    };
+        m = FRAME_RATE_RE.exec(fps_attr);
 
-    /*
-     * TTML element utility functions
-     * 
-     */
+        if (m !== null) {
 
-    function ContentElement(kind) {
-        this.kind = kind;
-    }
-
-    function IdentifiedElement(id) {
-        this.id = id;
-    }
-
-    IdentifiedElement.prototype.initFromNode = function (doc, parent, node, errorHandler) {
-        this.id = elementGetXMLID(node);
-    };
-
-    function LayoutElement(id) {
-        this.regionID = id;
-    }
-
-    LayoutElement.prototype.initFromNode = function (doc, parent, node, errorHandler) {
-        this.regionID = elementGetRegionID(node);
-    };
-
-    function StyledElement(styleAttrs) {
-        this.styleAttrs = styleAttrs;
-    }
-
-    StyledElement.prototype.initFromNode = function (doc, parent, node, errorHandler) {
-
-        this.styleAttrs = elementGetStyles(node, errorHandler);
-
-        if (doc.head !== null && doc.head.styling !== null) {
-            mergeReferencedStyles(doc.head.styling, elementGetStyleRefs(node), this.styleAttrs, errorHandler);
-        }
-
-    };
-
-    function AnimatedElement(sets) {
-        this.sets = sets;
-    }
-
-    AnimatedElement.prototype.initFromNode = function (doc, parent, node, errorHandler) {
-        this.sets = [];
-    };
-
-    function ContainerElement(contents) {
-        this.contents = contents;
-    }
-
-    ContainerElement.prototype.initFromNode = function (doc, parent, node, errorHandler) {
-        this.contents = [];
-    };
-
-    function TimedElement(explicit_begin, explicit_end, explicit_dur) {
-        this.explicit_begin = explicit_begin;
-        this.explicit_end = explicit_end;
-        this.explicit_dur = explicit_dur;
-    }
-
-    TimedElement.prototype.initFromNode = function (doc, parent, node, errorHandler) {
-        var t = processTiming(doc, parent, node, errorHandler);
-        this.explicit_begin = t.explicit_begin;
-        this.explicit_end = t.explicit_end;
-        this.explicit_dur = t.explicit_dur;
-
-        this.timeContainer = elementGetTimeContainer(node, errorHandler);
-    };
-
-
-    /*
-     * Represents a TTML body element
-     */
-
-
-
-    function Body() {
-        ContentElement.call(this, 'body');
-    }
-
-
-    Body.prototype.initFromNode = function (doc, node, xmllang, errorHandler) {
-        StyledElement.prototype.initFromNode.call(this, doc, null, node, errorHandler);
-        TimedElement.prototype.initFromNode.call(this, doc, null, node, errorHandler);
-        AnimatedElement.prototype.initFromNode.call(this, doc, null, node, errorHandler);
-        LayoutElement.prototype.initFromNode.call(this, doc, null, node, errorHandler);
-        ContainerElement.prototype.initFromNode.call(this, doc, null, node, errorHandler);
-
-        this.lang = xmllang;
-    };
-
-    /*
-     * Represents a TTML div element
-     */
-
-    function Div() {
-        ContentElement.call(this, 'div');
-    }
-
-    Div.prototype.initFromNode = function (doc, parent, node, xmllang, errorHandler) {
-        StyledElement.prototype.initFromNode.call(this, doc, parent, node, errorHandler);
-        TimedElement.prototype.initFromNode.call(this, doc, parent, node, errorHandler);
-        AnimatedElement.prototype.initFromNode.call(this, doc, parent, node, errorHandler);
-        LayoutElement.prototype.initFromNode.call(this, doc, parent, node, errorHandler);
-        ContainerElement.prototype.initFromNode.call(this, doc, parent, node, errorHandler);
-
-        this.lang = xmllang;
-    };
-
-    /*
-     * Represents a TTML p element
-     */
-
-    function P() {
-        ContentElement.call(this, 'p');
-    }
-
-    P.prototype.initFromNode = function (doc, parent, node, xmllang, errorHandler) {
-        StyledElement.prototype.initFromNode.call(this, doc, parent, node, errorHandler);
-        TimedElement.prototype.initFromNode.call(this, doc, parent, node, errorHandler);
-        AnimatedElement.prototype.initFromNode.call(this, doc, parent, node, errorHandler);
-        LayoutElement.prototype.initFromNode.call(this, doc, parent, node, errorHandler);
-        ContainerElement.prototype.initFromNode.call(this, doc, parent, node, errorHandler);
-
-        this.lang = xmllang;
-    };
-
-    /*
-     * Represents a TTML span element
-     */
-
-    function Span() {
-        ContentElement.call(this, 'span');
-    }
-
-    Span.prototype.initFromNode = function (doc, parent, node, xmllang, xmlspace, errorHandler) {
-        StyledElement.prototype.initFromNode.call(this, doc, parent, node, errorHandler);
-        TimedElement.prototype.initFromNode.call(this, doc, parent, node, errorHandler);
-        AnimatedElement.prototype.initFromNode.call(this, doc, parent, node, errorHandler);
-        LayoutElement.prototype.initFromNode.call(this, doc, parent, node, errorHandler);
-        ContainerElement.prototype.initFromNode.call(this, doc, parent, node, errorHandler);
-
-        this.space = xmlspace;
-        this.lang = xmllang;
-    };
-
-    /*
-     * Represents a TTML anonymous span element
-     */
-
-    function AnonymousSpan() {
-        ContentElement.call(this, 'span');
-    }
-
-    AnonymousSpan.prototype.initFromText = function (doc, parent, text, xmllang, xmlspace, errorHandler) {
-        TimedElement.prototype.initFromNode.call(this, doc, parent, null, errorHandler);
-
-        this.text = text;
-        this.space = xmlspace;
-        this.lang = xmllang;
-    };
-
-    /*
-     * Represents a TTML br element
-     */
-
-    function Br() {
-        ContentElement.call(this, 'br');
-    }
-
-    Br.prototype.initFromNode = function (doc, parent, node, xmllang, errorHandler) {
-        LayoutElement.prototype.initFromNode.call(this, doc, parent, node, errorHandler);
-        TimedElement.prototype.initFromNode.call(this, doc, parent, node, errorHandler);
-
-        this.lang = xmllang;
-    };
-
-    /*
-     * Represents a TTML Region element
-     * 
-     */
-
-    function Region() {
-    }
-
-    Region.prototype.createDefaultRegion = function (xmllang) {
-        var r = new Region();
-
-        IdentifiedElement.call(r, '');
-        StyledElement.call(r, {});
-        AnimatedElement.call(r, []);
-        TimedElement.call(r, 0, Number.POSITIVE_INFINITY, null);
-
-        this.lang = xmllang;
-
-        return r;
-    };
-
-    Region.prototype.initFromNode = function (doc, node, xmllang, errorHandler) {
-        IdentifiedElement.prototype.initFromNode.call(this, doc, null, node, errorHandler);
-        TimedElement.prototype.initFromNode.call(this, doc, null, node, errorHandler);
-        AnimatedElement.prototype.initFromNode.call(this, doc, null, node, errorHandler);
-
-        /* add specified styles */
-
-        this.styleAttrs = elementGetStyles(node, errorHandler);
-
-        /* remember referential styles for merging after nested styling is processed*/
-
-        this.styleRefs = elementGetStyleRefs(node);
-
-        /* xml:lang */
-
-        this.lang = xmllang;
-    };
-
-    /*
-     * Represents a TTML Set element
-     * 
-     */
-
-    function Set() {
-    }
-
-    Set.prototype.initFromNode = function (doc, parent, node, errorHandler) {
-
-        TimedElement.prototype.initFromNode.call(this, doc, parent, node, errorHandler);
-
-        var styles = elementGetStyles(node, errorHandler);
-
-        this.qname = null;
-        this.value = null;
-
-        for (var qname in styles) {
-
-            if (! styles.hasOwnProperty(qname)) continue;
-
-            if (this.qname) {
-
-                reportError(errorHandler, "More than one style specified on set");
-                break;
-
-            }
-
-            this.qname = qname;
-            this.value = styles[qname];
-
-        }
-
-    };
-
-    /*
-     * Utility functions
-     * 
-     */
-
-
-    function elementGetXMLID(node) {
-        return node && 'xml:id' in node.attributes ? node.attributes['xml:id'].value || null : null;
-    }
-
-    function elementGetRegionID(node) {
-        return node && 'region' in node.attributes ? node.attributes.region.value : '';
-    }
-
-    function elementGetTimeContainer(node, errorHandler) {
-
-        var tc = node && 'timeContainer' in node.attributes ? node.attributes.timeContainer.value : null;
-
-        if ((!tc) || tc === "par") {
-
-            return "par";
-
-        } else if (tc === "seq") {
-
-            return "seq";
+            fps = parseInt(m[1]);
 
         } else {
 
-            reportError(errorHandler, "Illegal value of timeContainer (assuming 'par')");
-
-            return "par";
-
+            reportWarning(errorHandler, 'Malformed frame rate attribute (using initial value instead)');
         }
 
     }
 
-    function elementGetStyleRefs(node) {
+    // extract frame rate multiplier
 
-        return node && 'style' in node.attributes ? node.attributes.style.value.split(" ") : [];
+    var frm_attr = findAttribute(node, imscNames.ns_ttp, 'frameRateMultiplier');
+
+    // initial value
+
+    var frm = 1;
+
+    if (frm_attr !== null) {
+
+        var FRAME_RATE_MULT_RE = /(\d+) (\d+)/;
+
+        m = FRAME_RATE_MULT_RE.exec(frm_attr);
+
+        if (m !== null) {
+
+            frm = parseInt(m[1]) / parseInt(m[2]);
+
+        } else {
+
+            reportWarning(errorHandler, 'Malformed frame rate multiplier attribute (using initial value instead)');
+        }
 
     }
 
-    function elementGetStyles(node, errorHandler) {
+    var efps = frm * fps;
 
-        var s = {};
+    // extract tick rate
 
-        if (node !== null) {
+    var tr = 1;
 
-            for (var i in node.attributes) {
+    var trattr = findAttribute(node, imscNames.ns_ttp, 'tickRate');
 
-                var qname = node.attributes[i].uri + " " + node.attributes[i].local;
+    if (trattr === null) {
 
-                var sa = imscStyles.byQName[qname];
+        if (fps_attr !== null)
+            tr = efps;
 
-                if (sa !== undefined) {
+    } else {
 
-                    var val = sa.parse(node.attributes[i].value);
+        var TICK_RATE_RE = /(\d+)/;
 
-                    if (val !== null) {
+        m = TICK_RATE_RE.exec(trattr);
 
-                        s[qname] = val;
+        if (m !== null) {
 
-                        /* TODO: consider refactoring errorHandler into parse and compute routines */
+            tr = parseInt(m[1]);
 
-                        if (sa === imscStyles.byName.zIndex) {
-                            reportWarning(errorHandler, "zIndex attribute present but not used by IMSC1 since regions do not overlap");
-                        }
+        } else {
 
-                    } else {
-
-                        reportError(errorHandler, "Cannot parse styling attribute " + qname + " --> " + node.attributes[i].value);
-
-                    }
-
-                }
-
-            }
-
+            reportWarning(errorHandler, 'Malformed tick rate attribute (using initial value instead)');
         }
 
-        return s;
     }
 
-    function findAttribute(node, ns, name) {
-        for (var i in node.attributes) {
+    return {effectiveFrameRate: efps, tickRate: tr};
 
-            if (node.attributes[i].uri === ns &&
-                    node.attributes[i].local === name) {
+}
 
-                return node.attributes[i].value;
-            }
-        }
+function extractExtent(node, errorHandler) {
+
+    var attr = findAttribute(node, imscNames.ns_tts, 'extent');
+
+    if (attr === null)
+        return null;
+
+    var s = attr.split(' ');
+
+    if (s.length !== 2) {
+
+        reportWarning(errorHandler, 'Malformed extent (ignoring)');
 
         return null;
     }
 
-    function extractAspectRatio(node, errorHandler) {
+    var w = imscUtils.parseLength(s[0]);
 
-        var ar = findAttribute(node, imscNames.ns_ittp, "aspectRatio");
+    var h = imscUtils.parseLength(s[1]);
 
-        if (ar === null) {
-            
-            ar = findAttribute(node, imscNames.ns_ttp, "displayAspectRatio");
-            
+    if (!h || !w) {
+
+        reportWarning(errorHandler, 'Malformed extent values (ignoring)');
+
+        return null;
+    }
+
+    return {'h': h, 'w': w};
+
+}
+
+function parseTimeExpression(tickRate, effectiveFrameRate, str) {
+
+    var CLOCK_TIME_FRACTION_RE = /^(\d{2,}):(\d\d):(\d\d(?:\.\d+)?)$/;
+    var CLOCK_TIME_FRAMES_RE = /^(\d{2,}):(\d\d):(\d\d):(\d{2,})$/;
+    var OFFSET_FRAME_RE = /^(\d+(?:\.\d+)?)f$/;
+    var OFFSET_TICK_RE = /^(\d+(?:\.\d+)?)t$/;
+    var OFFSET_MS_RE = /^(\d+(?:\.\d+)?)ms$/;
+    var OFFSET_S_RE = /^(\d+(?:\.\d+)?)s$/;
+    var OFFSET_H_RE = /^(\d+(?:\.\d+)?)h$/;
+    var OFFSET_M_RE = /^(\d+(?:\.\d+)?)m$/;
+    var m;
+    var r = null;
+    if ((m = OFFSET_FRAME_RE.exec(str)) !== null) {
+
+        if (effectiveFrameRate !== null) {
+
+            r = parseFloat(m[1]) / effectiveFrameRate;
         }
 
-        var rslt = null;
+    } else if ((m = OFFSET_TICK_RE.exec(str)) !== null) {
 
-        if (ar !== null) {
+        if (tickRate !== null) {
 
-            var ASPECT_RATIO_RE = /(\d+)\s+(\d+)/;
-
-            var m = ASPECT_RATIO_RE.exec(ar);
-
-            if (m !== null) {
-
-                var w = parseInt(m[1]);
-
-                var h = parseInt(m[2]);
-
-                if (w !== 0 && h !== 0) {
-
-                    rslt = w / h;
-
-                } else {
-
-                    reportError(errorHandler, "Illegal aspectRatio values (ignoring)");
-                }
-
-            } else {
-
-                reportError(errorHandler, "Malformed aspectRatio attribute (ignoring)");
-            }
-
+            r = parseFloat(m[1]) / tickRate;
         }
 
-        return rslt;
+    } else if ((m = OFFSET_MS_RE.exec(str)) !== null) {
+
+        r = parseFloat(m[1]) / 1000.0;
+
+    } else if ((m = OFFSET_S_RE.exec(str)) !== null) {
+
+        r = parseFloat(m[1]);
+
+    } else if ((m = OFFSET_H_RE.exec(str)) !== null) {
+
+        r = parseFloat(m[1]) * 3600.0;
+
+    } else if ((m = OFFSET_M_RE.exec(str)) !== null) {
+
+        r = parseFloat(m[1]) * 60.0;
+
+    } else if ((m = CLOCK_TIME_FRACTION_RE.exec(str)) !== null) {
+
+        r = parseInt(m[1]) * 3600 +
+            parseInt(m[2]) * 60 +
+            parseFloat(m[3]);
+
+    } else if ((m = CLOCK_TIME_FRAMES_RE.exec(str)) !== null) {
+
+        /* this assumes that HH:MM:SS is a clock-time-with-fraction */
+
+        if (effectiveFrameRate !== null) {
+
+            r = parseInt(m[1]) * 3600 +
+                parseInt(m[2]) * 60 +
+                parseInt(m[3]) +
+                (m[4] === null ? 0 : parseInt(m[4]) / effectiveFrameRate);
+        }
 
     }
 
-    /*
-     * Returns the cellResolution attribute from a node
-     * 
-     */
-    function extractCellResolution(node, errorHandler) {
+    return r;
+}
 
-        var cr = findAttribute(node, imscNames.ns_ttp, "cellResolution");
+function processTiming(doc, parent, node, errorHandler) {
 
-        // initial value
+    /* determine explicit begin */
 
-        var h = 15;
-        var w = 32;
+    var explicit_begin = null;
 
-        if (cr !== null) {
+    if (node && 'begin' in node.attributes) {
 
-            var CELL_RESOLUTION_RE = /(\d+) (\d+)/;
+        explicit_begin = parseTimeExpression(doc.tickRate, doc.effectiveFrameRate, node.attributes.begin.value);
 
-            var m = CELL_RESOLUTION_RE.exec(cr);
+        if (explicit_begin === null) {
 
-            if (m !== null) {
-
-                w = parseInt(m[1]);
-
-                h = parseInt(m[2]);
-
-            } else {
-
-                reportWarning(errorHandler, "Malformed cellResolution value (using initial value instead)");
-
-            }
+            reportWarning(errorHandler, 'Malformed begin value ' + node.attributes.begin.value + ' (using 0)');
 
         }
-
-        return {'w': w, 'h': h};
 
     }
 
+    /* determine explicit duration */
 
-    function extractFrameAndTickRate(node, errorHandler) {
+    var explicit_dur = null;
 
-        // subFrameRate is ignored per IMSC1 specification
+    if (node && 'dur' in node.attributes) {
 
-        // extract frame rate
+        explicit_dur = parseTimeExpression(doc.tickRate, doc.effectiveFrameRate, node.attributes.dur.value);
 
-        var fps_attr = findAttribute(node, imscNames.ns_ttp, "frameRate");
+        if (explicit_dur === null) {
 
-        // initial value
-
-        var fps = 30;
-
-        // match variable
-
-        var m;
-
-        if (fps_attr !== null) {
-
-            var FRAME_RATE_RE = /(\d+)/;
-
-            m = FRAME_RATE_RE.exec(fps_attr);
-
-            if (m !== null) {
-
-                fps = parseInt(m[1]);
-
-            } else {
-
-                reportWarning(errorHandler, "Malformed frame rate attribute (using initial value instead)");
-            }
+            reportWarning(errorHandler, 'Malformed dur value ' + node.attributes.dur.value + ' (ignoring)');
 
         }
 
-        // extract frame rate multiplier
+    }
 
-        var frm_attr = findAttribute(node, imscNames.ns_ttp, "frameRateMultiplier");
+    /* determine explicit end */
 
-        // initial value
+    var explicit_end = null;
 
-        var frm = 1;
+    if (node && 'end' in node.attributes) {
 
-        if (frm_attr !== null) {
+        explicit_end = parseTimeExpression(doc.tickRate, doc.effectiveFrameRate, node.attributes.end.value);
 
-            var FRAME_RATE_MULT_RE = /(\d+) (\d+)/;
+        if (explicit_end === null) {
 
-            m = FRAME_RATE_MULT_RE.exec(frm_attr);
-
-            if (m !== null) {
-
-                frm = parseInt(m[1]) / parseInt(m[2]);
-
-            } else {
-
-                reportWarning(errorHandler, "Malformed frame rate multiplier attribute (using initial value instead)");
-            }
+            reportWarning(errorHandler, 'Malformed end value (ignoring)');
 
         }
 
-        var efps = frm * fps;
+    }
 
-        // extract tick rate
+    return {
+        explicit_begin: explicit_begin,
+        explicit_end: explicit_end,
+        explicit_dur: explicit_dur
+    };
 
-        var tr = 1;
+}
 
-        var trattr = findAttribute(node, imscNames.ns_ttp, "tickRate");
 
-        if (trattr === null) {
+function mergeChainedStyles(styling, style, errorHandler) {
 
-            if (fps_attr !== null)
-                tr = efps;
+    while (style.styleRefs.length > 0) {
+
+        var sref = style.styleRefs.pop();
+
+        if (!(sref in styling.styles)) {
+            reportError(errorHandler, 'Non-existant style id referenced');
+            continue;
+        }
+
+        mergeChainedStyles(styling, styling.styles[sref], errorHandler);
+
+        mergeStylesIfNotPresent(styling.styles[sref].styleAttrs, style.styleAttrs);
+
+    }
+
+}
+
+function mergeReferencedStyles(styling, stylerefs, styleattrs, errorHandler) {
+
+    for (var i = stylerefs.length - 1; i >= 0; i--) {
+
+        var sref = stylerefs[i];
+
+        if (!(sref in styling.styles)) {
+            reportError(errorHandler, 'Non-existant style id referenced');
+            continue;
+        }
+
+        mergeStylesIfNotPresent(styling.styles[sref].styleAttrs, styleattrs);
+
+    }
+
+}
+
+function mergeStylesIfNotPresent(from_styles, into_styles) {
+
+    for (var sname in from_styles) {
+
+        if (!imscUtils.checkHasOwnProperty(from_styles, sname)) continue;
+
+        if (sname in into_styles)
+            continue;
+
+        into_styles[sname] = from_styles[sname];
+
+    }
+
+}
+
+/* TODO: validate style format at parsing */
+
+/*
+ * Binary search utility function
+ *
+ * @typedef {Object} BinarySearchResult
+ * @property {boolean} found Was an exact match found?
+ * @property {number} index Position of the exact match or insert position
+ *
+ * @returns {BinarySearchResult}
+ */
+
+function indexOf(arr, searchval) {
+
+    var min = 0;
+    var max = arr.length - 1;
+    var cur;
+
+    while (min <= max) {
+
+        cur = Math.floor((min + max) / 2);
+
+        var curval = arr[cur];
+
+        if (curval < searchval) {
+
+            min = cur + 1;
+
+        } else if (curval > searchval) {
+
+            max = cur - 1;
 
         } else {
 
-            var TICK_RATE_RE = /(\d+)/;
-
-            m = TICK_RATE_RE.exec(trattr);
-
-            if (m !== null) {
-
-                tr = parseInt(m[1]);
-
-            } else {
-
-                reportWarning(errorHandler, "Malformed tick rate attribute (using initial value instead)");
-            }
+            return {found: true, index: cur};
 
         }
 
-        return {effectiveFrameRate: efps, tickRate: tr};
-
     }
 
-    function extractExtent(node, errorHandler) {
+    return {found: false, index: min};
+}
 
-        var attr = findAttribute(node, imscNames.ns_tts, "extent");
-
-        if (attr === null)
-            return null;
-
-        var s = attr.split(" ");
-
-        if (s.length !== 2) {
-
-            reportWarning(errorHandler, "Malformed extent (ignoring)");
-
-            return null;
-        }
-
-        var w = imscUtils.parseLength(s[0]);
-
-        var h = imscUtils.parseLength(s[1]);
-
-        if (!h || !w) {
-
-            reportWarning(errorHandler, "Malformed extent values (ignoring)");
-
-            return null;
-        }
-
-        return {'h': h, 'w': w};
-
-    }
-
-    function parseTimeExpression(tickRate, effectiveFrameRate, str) {
-
-        var CLOCK_TIME_FRACTION_RE = /^(\d{2,}):(\d\d):(\d\d(?:\.\d+)?)$/;
-        var CLOCK_TIME_FRAMES_RE = /^(\d{2,}):(\d\d):(\d\d)\:(\d{2,})$/;
-        var OFFSET_FRAME_RE = /^(\d+(?:\.\d+)?)f$/;
-        var OFFSET_TICK_RE = /^(\d+(?:\.\d+)?)t$/;
-        var OFFSET_MS_RE = /^(\d+(?:\.\d+)?)ms$/;
-        var OFFSET_S_RE = /^(\d+(?:\.\d+)?)s$/;
-        var OFFSET_H_RE = /^(\d+(?:\.\d+)?)h$/;
-        var OFFSET_M_RE = /^(\d+(?:\.\d+)?)m$/;
-        var m;
-        var r = null;
-        if ((m = OFFSET_FRAME_RE.exec(str)) !== null) {
-
-            if (effectiveFrameRate !== null) {
-
-                r = parseFloat(m[1]) / effectiveFrameRate;
-            }
-
-        } else if ((m = OFFSET_TICK_RE.exec(str)) !== null) {
-
-            if (tickRate !== null) {
-
-                r = parseFloat(m[1]) / tickRate;
-            }
-
-        } else if ((m = OFFSET_MS_RE.exec(str)) !== null) {
-
-            r = parseFloat(m[1]) / 1000.0;
-
-        } else if ((m = OFFSET_S_RE.exec(str)) !== null) {
-
-            r = parseFloat(m[1]);
-
-        } else if ((m = OFFSET_H_RE.exec(str)) !== null) {
-
-            r = parseFloat(m[1]) * 3600.0;
-
-        } else if ((m = OFFSET_M_RE.exec(str)) !== null) {
-
-            r = parseFloat(m[1]) * 60.0;
-
-        } else if ((m = CLOCK_TIME_FRACTION_RE.exec(str)) !== null) {
-
-            r = parseInt(m[1]) * 3600 +
-                    parseInt(m[2]) * 60 +
-                    parseFloat(m[3]);
-
-        } else if ((m = CLOCK_TIME_FRAMES_RE.exec(str)) !== null) {
-
-            /* this assumes that HH:MM:SS is a clock-time-with-fraction */
-
-            if (effectiveFrameRate !== null) {
-
-                r = parseInt(m[1]) * 3600 +
-                        parseInt(m[2]) * 60 +
-                        parseInt(m[3]) +
-                        (m[4] === null ? 0 : parseInt(m[4]) / effectiveFrameRate);
-            }
-
-        }
-
-        return r;
-    }
-
-    function processTiming(doc, parent, node, errorHandler) {
-
-        /* determine explicit begin */
-
-        var explicit_begin = null;
-
-        if (node && 'begin' in node.attributes) {
-
-            explicit_begin = parseTimeExpression(doc.tickRate, doc.effectiveFrameRate, node.attributes.begin.value);
-
-            if (explicit_begin === null) {
-
-                reportWarning(errorHandler, "Malformed begin value " + node.attributes.begin.value + " (using 0)");
-
-            }
-
-        }
-
-        /* determine explicit duration */
-
-        var explicit_dur = null;
-
-        if (node && 'dur' in node.attributes) {
-
-            explicit_dur = parseTimeExpression(doc.tickRate, doc.effectiveFrameRate, node.attributes.dur.value);
-
-            if (explicit_dur === null) {
-
-                reportWarning(errorHandler, "Malformed dur value " + node.attributes.dur.value + " (ignoring)");
-
-            }
-
-        }
-
-        /* determine explicit end */
-
-        var explicit_end = null;
-
-        if (node && 'end' in node.attributes) {
-
-            explicit_end = parseTimeExpression(doc.tickRate, doc.effectiveFrameRate, node.attributes.end.value);
-
-            if (explicit_end === null) {
-
-                reportWarning(errorHandler, "Malformed end value (ignoring)");
-
-            }
-
-        }
-
-        return {explicit_begin: explicit_begin,
-            explicit_end: explicit_end,
-            explicit_dur: explicit_dur};
-
-    }
-
-
-
-    function mergeChainedStyles(styling, style, errorHandler) {
-
-        while (style.styleRefs.length > 0) {
-
-            var sref = style.styleRefs.pop();
-
-            if (!(sref in styling.styles)) {
-                reportError(errorHandler, "Non-existant style id referenced");
-                continue;
-            }
-
-            mergeChainedStyles(styling, styling.styles[sref], errorHandler);
-
-            mergeStylesIfNotPresent(styling.styles[sref].styleAttrs, style.styleAttrs);
-
-        }
-
-    }
-
-    function mergeReferencedStyles(styling, stylerefs, styleattrs, errorHandler) {
-
-        for (var i = stylerefs.length - 1; i >= 0; i--) {
-
-            var sref = stylerefs[i];
-
-            if (!(sref in styling.styles)) {
-                reportError(errorHandler, "Non-existant style id referenced");
-                continue;
-            }
-
-            mergeStylesIfNotPresent(styling.styles[sref].styleAttrs, styleattrs);
-
-        }
-
-    }
-
-    function mergeStylesIfNotPresent(from_styles, into_styles) {
-
-        for (var sname in from_styles) {
-
-            if (! from_styles.hasOwnProperty(sname)) continue;
-
-            if (sname in into_styles)
-                continue;
-
-            into_styles[sname] = from_styles[sname];
-
-        }
-
-    }
-
-    /* TODO: validate style format at parsing */
-
-
-    /*
-     * ERROR HANDLING UTILITY FUNCTIONS
-     * 
-     */
-
-    function reportInfo(errorHandler, msg) {
-
-        if (errorHandler && errorHandler.info && errorHandler.info(msg))
-            throw msg;
-
-    }
-
-    function reportWarning(errorHandler, msg) {
-
-        if (errorHandler && errorHandler.warn && errorHandler.warn(msg))
-            throw msg;
-
-    }
-
-    function reportError(errorHandler, msg) {
-
-        if (errorHandler && errorHandler.error && errorHandler.error(msg))
-            throw msg;
-
-    }
-
-    function reportFatal(errorHandler, msg) {
-
-        if (errorHandler && errorHandler.fatal)
-            errorHandler.fatal(msg);
-
-        throw msg;
-
-    }
-
-    /*
-     * Binary search utility function
-     * 
-     * @typedef {Object} BinarySearchResult
-     * @property {boolean} found Was an exact match found?
-     * @property {number} index Position of the exact match or insert position
-     * 
-     * @returns {BinarySearchResult}
-     */
-
-    function indexOf(arr, searchval) {
-
-        var min = 0;
-        var max = arr.length - 1;
-        var cur;
-
-        while (min <= max) {
-
-            cur = Math.floor((min + max) / 2);
-
-            var curval = arr[cur];
-
-            if (curval < searchval) {
-
-                min = cur + 1;
-
-            } else if (curval > searchval) {
-
-                max = cur - 1;
-
-            } else {
-
-                return {found: true, index: cur};
-
-            }
-
-        }
-
-        return {found: false, index: min};
-    }
-
-
-})(typeof exports === 'undefined' ? this.imscDoc = {} : exports,
-        typeof sax === 'undefined' ? require("sax") : sax,
-        typeof imscNames === 'undefined' ? require("./names") : imscNames,
-        typeof imscStyles === 'undefined' ? require("./styles") : imscStyles,
-        typeof imscUtils === 'undefined' ? require("./utils") : imscUtils);
+module.exports = imscDoc;

--- a/src/main/js/error.js
+++ b/src/main/js/error.js
@@ -1,0 +1,94 @@
+
+/**
+ * @classdesc Generic interface for handling events. The interface exposes four
+ * methods:
+ * * <pre>info</pre>: unusual event that does not result in an inconsistent state
+ * * <pre>warn</pre>: unexpected event that should not result in an inconsistent state
+ * * <pre>error</pre>: unexpected event that may result in an inconsistent state
+ * * <pre>fatal</pre>: unexpected event that results in an inconsistent state
+ *   and termination of processing
+ * Each method takes a single <pre>string</pre> describing the event as argument,
+ * and returns a single <pre>boolean</pre>, which terminates processing if <pre>true</pre>.
+ * @interface
+ */
+class ErrorHandler {
+
+    /**
+     * unusual event that does not result in an inconsistent state
+     * @param {unknown} msg
+     * @returns {boolean}
+     */
+    info(msg) { this._noop(msg); }
+
+    /**
+     * unexpected event that should not result in an inconsistent state
+     * @param {unknown} msg
+     * @returns {boolean}
+     */
+    warn(msg) { this._noop(msg); }
+
+    /**
+     * unexpected event that may result in an inconsistent state
+     * @param {unknown} msg
+     * @returns {boolean}
+     */
+    error(msg) { this._noop(msg); }
+
+    /**
+     * unexpected event that results in an inconsistent state
+     *   and termination of processing
+     * @param {unknown} msg
+     * @returns {boolean}
+     */
+    fatal(msg) { this._noop(msg); }
+
+    /**
+     * A method to trick eslint no-unused-vars check for this interface
+     * @private
+     */
+    _noop(msg) { return msg; }
+}
+
+
+/*
+ * ERROR HANDLING UTILITY FUNCTIONS
+ *
+ */
+
+function reportInfo(errorHandler, msg) {
+
+    if (errorHandler && errorHandler.info && errorHandler.info(msg))
+        throw msg;
+
+}
+
+function reportWarning(errorHandler, msg) {
+
+    if (errorHandler && errorHandler.warn && errorHandler.warn(msg))
+        throw msg;
+
+}
+
+function reportError(errorHandler, msg) {
+
+    if (errorHandler && errorHandler.error && errorHandler.error(msg))
+        throw msg;
+
+}
+
+function reportFatal(errorHandler, msg) {
+
+    if (errorHandler && errorHandler.fatal)
+        errorHandler.fatal(msg);
+
+    throw msg;
+
+}
+
+module.exports = {
+    reportInfo,
+    reportWarning,
+    reportError,
+    reportFatal,
+    ErrorHandler // just an interface, though
+};

--- a/src/main/js/html.js
+++ b/src/main/js/html.js
@@ -28,812 +28,1552 @@
  * @module imscHTML
  */
 
-;
-(function (imscHTML, imscNames, imscStyles) {
-
-    /**
-     * Function that maps <pre>smpte:background</pre> URIs to URLs resolving to image resource
-     * @callback IMGResolver
-     * @param {string} <pre>smpte:background</pre> URI
-     * @return {string} PNG resource URL
-     */
-
-
-    /**
-     * Renders an ISD object (returned by <pre>generateISD()</pre>) into a 
-     * parent element, that must be attached to the DOM. The ISD will be rendered
-     * into a child <pre>div</pre>
-     * with heigh and width equal to the clientHeight and clientWidth of the element,
-     * unless explicitly specified otherwise by the caller. Images URIs specified 
-     * by <pre>smpte:background</pre> attributes are mapped to image resource URLs
-     * by an <pre>imgResolver</pre> function. The latter takes the value of <code>smpte:background</code>
-     * attribute and an <code>img</code> DOM element as input, and is expected to
-     * set the <code>src</code> attribute of the <code>img</code> to the absolute URI of the image.
-     * <pre>displayForcedOnlyMode</pre> sets the (boolean)
-     * value of the IMSC1 displayForcedOnlyMode parameter. The function returns
-     * an opaque object that should passed in <code>previousISDState</code> when this function
-     * is called for the next ISD, otherwise <code>previousISDState</code> should be set to 
-     * <code>null</code>.
-     * 
-     * @param {Object} isd ISD to be rendered
-     * @param {Object} element Element into which the ISD is rendered
-     * @param {?IMGResolver} imgResolver Resolve <pre>smpte:background</pre> URIs into URLs.
-     * @param {?number} eheight Height (in pixel) of the child <div>div</div> or null 
-     *                  to use clientHeight of the parent element
-     * @param {?number} ewidth Width (in pixel) of the child <div>div</div> or null
-     *                  to use clientWidth of the parent element
-     * @param {?boolean} displayForcedOnlyMode Value of the IMSC1 displayForcedOnlyMode parameter,
-     *                   or false if null         
-     * @param {?module:imscUtils.ErrorHandler} errorHandler Error callback
-     * @param {Object} previousISDState State saved during processing of the previous ISD, or null if initial call
-     * @param {?boolean} enableRollUp Enables roll-up animations (see CEA 708)
-     * @return {Object} ISD state to be provided when this funtion is called for the next ISD
-     */
-
-    imscHTML.render = function (isd,
-            element,
-            imgResolver,
-            eheight,
-            ewidth,
-            displayForcedOnlyMode,
-            errorHandler,
-            previousISDState,
-            enableRollUp
-            ) {
-
-        /* maintain aspect ratio if specified */
-
-        var height = eheight || element.clientHeight;
-        var width = ewidth || element.clientWidth;
-
-        if (isd.aspectRatio !== null) {
-
-            var twidth = height * isd.aspectRatio;
-
-            if (twidth > width) {
-
-                height = Math.round(width / isd.aspectRatio);
-
-            } else {
-
-                width = twidth;
-
-            }
-
-        }
-
-        var rootcontainer = document.createElement("div");
-
-        rootcontainer.style.position = "relative";
-        rootcontainer.style.width = width + "px";
-        rootcontainer.style.height = height + "px";
-        rootcontainer.style.margin = "auto";
-        rootcontainer.style.top = 0;
-        rootcontainer.style.bottom = 0;
-        rootcontainer.style.left = 0;
-        rootcontainer.style.right = 0;
-        rootcontainer.style.zIndex = 0;
-
-        var context = {
-            h: height,
-            w: width,
-            regionH: null,
-            regionW: null,
-            imgResolver: imgResolver,
-            displayForcedOnlyMode: displayForcedOnlyMode || false,
-            isd: isd,
-            errorHandler: errorHandler,
-            previousISDState: previousISDState,
-            enableRollUp: enableRollUp || false,
-            currentISDState: {},
-            flg: null, /* current fillLineGap value if active, null otherwise */
-            lp: null, /* current linePadding value if active, null otherwise */
-            mra: null, /* current multiRowAlign value if active, null otherwise */
-            ipd: null, /* inline progression direction (lr, rl, tb) */
-            bpd: null, /* block progression direction (lr, rl, tb) */
-            ruby: null, /* is ruby present in a <p> */
-            textEmphasis: null, /* is textEmphasis present in a <p> */
-            rubyReserve: null /* is rubyReserve applicable to a <p> */
-        };
-
-        element.appendChild(rootcontainer);
-
-        if ("contents" in isd) {
-
-            for (var i = 0; i < isd.contents.length; i++) {
-
-                processElement(context, rootcontainer, isd.contents[i], isd);
-
-            }
-
-        }
-
-        return context.currentISDState;
-
-    };
-
-    function processElement(context, dom_parent, isd_element, isd_parent) {
-
-        var e;
-
-        if (isd_element.kind === 'region') {
-
-            e = document.createElement("div");
-            e.style.position = "absolute";
-
-        } else if (isd_element.kind === 'body') {
-
-            e = document.createElement("div");
-
-        } else if (isd_element.kind === 'div') {
-
-            e = document.createElement("div");
-
-        } else if (isd_element.kind === 'image') {
-
-            e = document.createElement("img");
-
-            if (context.imgResolver !== null && isd_element.src !== null) {
-
-                var uri = context.imgResolver(isd_element.src, e);
-
-                if (uri)
-                    e.src = uri;
-
-                e.height = context.regionH;
-                e.width = context.regionW;
-
-            }
-
-        } else if (isd_element.kind === 'p') {
-
-            e = document.createElement("p");
-
-        } else if (isd_element.kind === 'span') {
-
-            if (isd_element.styleAttrs[imscStyles.byName.ruby.qname] === "container") {
-
-                e = document.createElement("ruby");
-
-                context.ruby = true;
-
-            } else if (isd_element.styleAttrs[imscStyles.byName.ruby.qname] === "base") {
-
-                e = document.createElement("rb");
-
-            } else if (isd_element.styleAttrs[imscStyles.byName.ruby.qname] === "text") {
-
-                e = document.createElement("rt");
-
-
-            } else if (isd_element.styleAttrs[imscStyles.byName.ruby.qname] === "baseContainer") {
-
-                e = document.createElement("rbc");
-
-
-            } else if (isd_element.styleAttrs[imscStyles.byName.ruby.qname] === "textContainer") {
-
-                e = document.createElement("rtc");
-
-
-            } else if (isd_element.styleAttrs[imscStyles.byName.ruby.qname] === "delimiter") {
-
-                /* ignore rp */
-
-                return;
-
-            } else {
-
-                e = document.createElement("span");
-
-            }
-
-            //e.textContent = isd_element.text;
-
-        } else if (isd_element.kind === 'br') {
-
-            e = document.createElement("br");
-
-        }
-
-        if (!e) {
-
-            reportError(context.errorHandler, "Error processing ISD element kind: " + isd_element.kind);
-
-            return;
-
-        }
-
-        /* set language */
-
-        if (isd_element.lang) {
-
-            if (isd_element.kind === 'region' || isd_element.lang !== isd_parent.lang) {
-                e.lang = isd_element.lang;
-            }
-
-        }
-
-        /* add to parent */
-
-        dom_parent.appendChild(e);
-
-        /* override UA default margin */
-        /* TODO: should apply to <p> only */
-
-        e.style.margin = "0";
-
-        /* determine ipd and bpd */
-
-        if (isd_element.kind === "region") {
-
-            var wdir = isd_element.styleAttrs[imscStyles.byName.writingMode.qname];
-
-            if (wdir === "lrtb" || wdir === "lr") {
-
-                context.ipd = "lr";
-                context.bpd = "tb";
-
-            } else if (wdir === "rltb" || wdir === "rl") {
-
-                context.ipd = "rl";
-                context.bpd = "tb";
-
-            } else if (wdir === "tblr") {
-
-                context.ipd = "tb";
-                context.bpd = "lr";
-
-            } else if (wdir === "tbrl" || wdir === "tb") {
-
-                context.ipd = "tb";
-                context.bpd = "rl";
-
-            }
- 
-        } else if (isd_element.kind === "p" && context.bpd === "tb") {
-
-            var pdir = isd_element.styleAttrs[imscStyles.byName.direction.qname];
-
-            context.ipd = pdir === "ltr" ? "lr" : "rl"; 
- 
-        }
-
-        /* tranform TTML styles to CSS styles */
-
-        for (var i = 0; i < STYLING_MAP_DEFS.length; i++) {
-
-            var sm = STYLING_MAP_DEFS[i];
-
-            var attr = isd_element.styleAttrs[sm.qname];
-
-            if (attr !== undefined && sm.map !== null) {
-
-                sm.map(context, e, isd_element, attr);
-
-            }
-
-        }
-
-        var proc_e = e;
-
-        /* do we have linePadding ? */
-
-        var lp = isd_element.styleAttrs[imscStyles.byName.linePadding.qname];
-
-        if (lp && (! lp.isZero())) {
-
-            var plength = lp.toUsedLength(context.w, context.h);
-
-
-            if (plength > 0) {
-                
-                /* apply padding to the <p> so that line padding does not cause line wraps */
-
-                var padmeasure = Math.ceil(plength) + "px";
-
-                if (context.bpd === "tb") {
-
-                    proc_e.style.paddingLeft = padmeasure;
-                    proc_e.style.paddingRight = padmeasure;
-
-                } else {
-
-                    proc_e.style.paddingTop = padmeasure;
-                    proc_e.style.paddingBottom = padmeasure;
-
-                }
-
-                context.lp = lp;
-            }
-        }
-
-        // do we have multiRowAlign?
-
-        var mra = isd_element.styleAttrs[imscStyles.byName.multiRowAlign.qname];
-
-        if (mra && mra !== "auto") {
-
-            /* create inline block to handle multirowAlign */
-
-            var s = document.createElement("span");
-
-            s.style.display = "inline-block";
-
-            s.style.textAlign = mra;
-
-            e.appendChild(s);
-
-            proc_e = s;
-
-            context.mra = mra;
-
-        }
-
-        /* do we have rubyReserve? */
-
-        var rr = isd_element.styleAttrs[imscStyles.byName.rubyReserve.qname];
-
-        if (rr && rr[0] !== "none") {
-            context.rubyReserve = rr;
-        }
-
-
-        /* remember we are filling line gaps */
-
-        if (isd_element.styleAttrs[imscStyles.byName.fillLineGap.qname]) {
-            context.flg = true;
-        }
-
-
-        if (isd_element.kind === "span" && isd_element.text) {
-
-            var te = isd_element.styleAttrs[imscStyles.byName.textEmphasis.qname];
-
-            if (te && te.style !== "none") {
-
-                context.textEmphasis = true;
-
-            }
-
-            if (imscStyles.byName.textCombine.qname in isd_element.styleAttrs &&
-                    isd_element.styleAttrs[imscStyles.byName.textCombine.qname] === "all") {
-
-                /* ignore tate-chu-yoku since line break cannot happen within */
-                e.textContent = isd_element.text;
-
-                if (te) {
-
-                    applyTextEmphasis(context, e, isd_element, te);
-
-                };
-
-            } else {
-
-                // wrap characters in spans to find the line wrap locations
-
-                var cbuf = '';
-
-                for (var j = 0; j < isd_element.text.length; j++) {
-
-                    cbuf += isd_element.text.charAt(j);
-
-                    var cc = isd_element.text.charCodeAt(j);
-
-                    if (cc < 0xD800 || cc > 0xDBFF || j === isd_element.text.length - 1) {
-
-                        /* wrap the character(s) in a span unless it is a high surrogate */
-
-                        var span = document.createElement("span");
-
-                        span.textContent = cbuf;
-
-                        /* apply textEmphasis */
-                        
-                        if (te) {
-
-                            applyTextEmphasis(context, span, isd_element, te);
-
-                        };
-    
-                        e.appendChild(span);
-
-                        cbuf = '';
-
-                        //For the sake of merging these back together, record what isd element generated it.
-                        span._isd_element = isd_element;
-                    }
-
-                }
-
-            }
-        }
-
-        /* process the children of the ISD element */
-
-        if ("contents" in isd_element) {
-
-            for (var k = 0; k < isd_element.contents.length; k++) {
-
-                processElement(context, proc_e, isd_element.contents[k], isd_element);
-
-            }
-
-        }
-
-        /* list of lines */
-
-        var linelist = [];
-
-
-        /* paragraph processing */
-        /* TODO: linePadding only supported for horizontal scripts */
-
-        if (isd_element.kind === "p") {
-
-            constructLineList(context, proc_e, linelist, null);
-
-            /* apply rubyReserve */
-
-            if (context.rubyReserve) {
-
-                applyRubyReserve(linelist, context);
-
-                context.rubyReserve = null;
-
-            }
-
-            /* apply tts:rubyPosition="outside" */
-
-            if (context.ruby || context.rubyReserve) {
-
-                applyRubyPosition(linelist, context);
-
-                context.ruby = null;
-
-            }
-
-            /* apply text emphasis "outside" position */
-
-            if (context.textEmphasis) {
-
-                applyTextEmphasisOutside(linelist, context);
-
-                context.textEmphasis = null;
-
-            }
-
-            /* insert line breaks for multirowalign */
-
-            if (context.mra) {
-
-                applyMultiRowAlign(linelist);
-
-                context.mra = null;
-
-            }
-
-            /* add linepadding */
-
-            if (context.lp) {
-
-                applyLinePadding(linelist, context.lp.toUsedLength(context.w, context.h), context);
-
-                context.lp = null;
-
-            }
-
-            mergeSpans(linelist); // The earlier we can do this the less processing there will be.
-
-            /* fill line gaps linepadding */
-
-            if (context.flg) {
-
-                var par_edges = rect2edges(proc_e.getBoundingClientRect(), context);
-
-                applyFillLineGap(linelist, par_edges.before, par_edges.after, context, proc_e);
-
-                context.flg = null;
-
-            }
-
-        }
-
-
-        /* region processing */
-
-        if (isd_element.kind === "region") {
-
-            /* perform roll up if needed */
-            if ((context.bpd === "tb") &&
-                    context.enableRollUp &&
-                    isd_element.contents.length > 0 &&
-                    isd_element.styleAttrs[imscStyles.byName.displayAlign.qname] === 'after') {
-
-                /* build line list */
-                constructLineList(context, proc_e, linelist, null);
-
-                /* horrible hack, perhaps default region id should be underscore everywhere? */
-
-                var rid = isd_element.id === '' ? '_' : isd_element.id;
-
-                var rb = new RegionPBuffer(rid, linelist);
-
-                context.currentISDState[rb.id] = rb;
-
-                if (context.previousISDState &&
-                        rb.id in context.previousISDState &&
-                        context.previousISDState[rb.id].plist.length > 0 &&
-                        rb.plist.length > 1 &&
-                        rb.plist[rb.plist.length - 2].text ===
-                        context.previousISDState[rb.id].plist[context.previousISDState[rb.id].plist.length - 1].text) {
-
-                    var body_elem = e.firstElementChild;
-
-                    var h = rb.plist[rb.plist.length - 1].after - rb.plist[rb.plist.length - 1].before;
-
-                    body_elem.style.bottom = "-" + h + "px";
-                    body_elem.style.transition = "transform 0.4s";
-                    body_elem.style.position = "relative";
-                    body_elem.style.transform = "translateY(-" + h + "px)";
-
-                }
-
-            }
-        }
-    }
-
-    function mergeSpans(lineList) {
-
-        for (var i = 0; i < lineList.length; i++) {
-
-            var line = lineList[i];
-
-            for (var j = 1; j < line.elements.length;) {
-
-                var previous = line.elements[j - 1];
-                var span = line.elements[j];
-
-                if (spanMerge(previous.node, span.node)) {
-
-                    //removed from DOM by spanMerge(), remove from the list too.
-                    line.elements.splice(j, 1);
-                    continue;
-
-                } else {
-
-                    j++;
-
-                }
-
-            }
-        }
-
-        // Copy backgroundColor to each span so that fillLineGap will apply padding to elements with the right background
-        var thisNode, ancestorBackgroundColor;
-        var clearTheseBackgrounds = [];
-
-        for (var l = 0; l < lineList.length; l++) {
-
-            for (var el = 0; el < lineList[l].elements.length; el++) {
-
-                thisNode = lineList[l].elements[el].node;
-                ancestorBackgroundColor = getSpanAncestorColor(thisNode, clearTheseBackgrounds, false);
-
-                if (ancestorBackgroundColor) {
-
-                    thisNode.style.backgroundColor = ancestorBackgroundColor;
-
-                }
-            }
-        }
-
-        for (var bi = 0; bi < clearTheseBackgrounds.length; bi++) {
-
-            clearTheseBackgrounds[bi].style.backgroundColor = "";
-
-        }
-    }
-
-    function getSpanAncestorColor(element, ancestorList, isAncestor) {
-
-        if (element.style.backgroundColor) {
-
-            if (isAncestor && !ancestorList.includes(element)) {
-
-                ancestorList.push(element);
-
-            }
-            return element.style.backgroundColor;
+const imscHTML = {};
+const imscStyles = require('./styles');
+const {reportError} = require('./error');
+
+/**
+ * Function that maps <pre>smpte:background</pre> URIs to URLs resolving to image resource
+ * @callback IMGResolver
+ * @param {string} <pre>smpte:background</pre> URI
+ * @return {string} PNG resource URL
+ */
+
+
+/**
+ * Renders an ISD object (returned by <pre>generateISD()</pre>) into a
+ * parent element, that must be attached to the DOM. The ISD will be rendered
+ * into a child <pre>div</pre>
+ * with heigh and width equal to the clientHeight and clientWidth of the element,
+ * unless explicitly specified otherwise by the caller. Images URIs specified
+ * by <pre>smpte:background</pre> attributes are mapped to image resource URLs
+ * by an <pre>imgResolver</pre> function. The latter takes the value of <code>smpte:background</code>
+ * attribute and an <code>img</code> DOM element as input, and is expected to
+ * set the <code>src</code> attribute of the <code>img</code> to the absolute URI of the image.
+ * <pre>displayForcedOnlyMode</pre> sets the (boolean)
+ * value of the IMSC1 displayForcedOnlyMode parameter. The function returns
+ * an opaque object that should passed in <code>previousISDState</code> when this function
+ * is called for the next ISD, otherwise <code>previousISDState</code> should be set to
+ * <code>null</code>.
+ *
+ * @param {Object} isd ISD to be rendered
+ * @param {Object} element Element into which the ISD is rendered
+ * @param {?IMGResolver} imgResolver Resolve <pre>smpte:background</pre> URIs into URLs.
+ * @param {?number} eheight Height (in pixel) of the child <div>div</div> or null
+ *                  to use clientHeight of the parent element
+ * @param {?number} ewidth Width (in pixel) of the child <div>div</div> or null
+ *                  to use clientWidth of the parent element
+ * @param {?boolean} displayForcedOnlyMode Value of the IMSC1 displayForcedOnlyMode parameter,
+ *                   or false if null
+ * @param {?module:imscUtils.ErrorHandler} errorHandler Error callback
+ * @param {Object} previousISDState State saved during processing of the previous ISD, or null if initial call
+ * @param {?boolean} enableRollUp Enables roll-up animations (see CEA 708)
+ * @return {Object} ISD state to be provided when this funtion is called for the next ISD
+ */
+
+imscHTML.render = function (isd,
+    element,
+    imgResolver,
+    eheight,
+    ewidth,
+    displayForcedOnlyMode,
+    errorHandler,
+    previousISDState,
+    enableRollUp
+) {
+
+    /* maintain aspect ratio if specified */
+
+    var height = eheight || element.clientHeight;
+    var width = ewidth || element.clientWidth;
+
+    if (isd.aspectRatio !== null) {
+
+        var twidth = height * isd.aspectRatio;
+
+        if (twidth > width) {
+
+            height = Math.round(width / isd.aspectRatio);
 
         } else {
 
-            if (element.parentElement.nodeName === "SPAN") {
-
-                return getSpanAncestorColor(element.parentElement, ancestorList, true);
-
-            }
+            width = twidth;
 
         }
 
-        return undefined;
     }
 
-    function spanMerge(first, second) {
+    var rootcontainer = document.createElement('div');
 
-        if (first.tagName === "SPAN" &&
-            second.tagName === "SPAN" &&
-            first._isd_element === second._isd_element) {
+    rootcontainer.style.position = 'relative';
+    rootcontainer.style.width = width + 'px';
+    rootcontainer.style.height = height + 'px';
+    rootcontainer.style.margin = 'auto';
+    rootcontainer.style.top = 0;
+    rootcontainer.style.bottom = 0;
+    rootcontainer.style.left = 0;
+    rootcontainer.style.right = 0;
+    rootcontainer.style.zIndex = 0;
 
-                first.textContent += second.textContent;
+    var context = {
+        h: height,
+        w: width,
+        regionH: null,
+        regionW: null,
+        imgResolver: imgResolver,
+        displayForcedOnlyMode: displayForcedOnlyMode || false,
+        isd: isd,
+        errorHandler: errorHandler,
+        previousISDState: previousISDState,
+        enableRollUp: enableRollUp || false,
+        currentISDState: {},
+        flg: null, /* current fillLineGap value if active, null otherwise */
+        lp: null, /* current linePadding value if active, null otherwise */
+        mra: null, /* current multiRowAlign value if active, null otherwise */
+        ipd: null, /* inline progression direction (lr, rl, tb) */
+        bpd: null, /* block progression direction (lr, rl, tb) */
+        ruby: null, /* is ruby present in a <p> */
+        textEmphasis: null, /* is textEmphasis present in a <p> */
+        rubyReserve: null /* is rubyReserve applicable to a <p> */
+    };
 
-                for (var i = 0; i < second.style.length; i++) {
+    element.appendChild(rootcontainer);
 
-                    var styleName = second.style[i];
-                    if (styleName.indexOf("border") >= 0 || 
-                        styleName.indexOf("padding") >= 0 ||
-                        styleName.indexOf("margin") >= 0) {
+    if ('contents' in isd) {
 
-                        first.style[styleName] = second.style[styleName];
+        for (var i = 0; i < isd.contents.length; i++) {
 
-                    }
-                }
+            processElement(context, rootcontainer, isd.contents[i], isd);
 
-                second.parentElement.removeChild(second);
+        }
 
-                return true;
+    }
+
+    return context.currentISDState;
+
+};
+
+function processElement(context, dom_parent, isd_element, isd_parent) {
+
+    var e;
+
+    if (isd_element.kind === 'region') {
+
+        e = document.createElement('div');
+        e.style.position = 'absolute';
+
+    } else if (isd_element.kind === 'body') {
+
+        e = document.createElement('div');
+
+    } else if (isd_element.kind === 'div') {
+
+        e = document.createElement('div');
+
+    } else if (isd_element.kind === 'image') {
+
+        e = document.createElement('img');
+
+        if (context.imgResolver !== null && isd_element.src !== null) {
+
+            var uri = context.imgResolver(isd_element.src, e);
+
+            if (uri)
+                e.src = uri;
+
+            e.height = context.regionH;
+            e.width = context.regionW;
+
+        }
+
+    } else if (isd_element.kind === 'p') {
+
+        e = document.createElement('p');
+
+    } else if (isd_element.kind === 'span') {
+
+        if (isd_element.styleAttrs[imscStyles.byName.ruby.qname] === 'container') {
+
+            e = document.createElement('ruby');
+
+            context.ruby = true;
+
+        } else if (isd_element.styleAttrs[imscStyles.byName.ruby.qname] === 'base') {
+
+            e = document.createElement('rb');
+
+        } else if (isd_element.styleAttrs[imscStyles.byName.ruby.qname] === 'text') {
+
+            e = document.createElement('rt');
+
+
+        } else if (isd_element.styleAttrs[imscStyles.byName.ruby.qname] === 'baseContainer') {
+
+            e = document.createElement('rbc');
+
+
+        } else if (isd_element.styleAttrs[imscStyles.byName.ruby.qname] === 'textContainer') {
+
+            e = document.createElement('rtc');
+
+
+        } else if (isd_element.styleAttrs[imscStyles.byName.ruby.qname] === 'delimiter') {
+
+            /* ignore rp */
+
+            return;
+
+        } else {
+
+            e = document.createElement('span');
+
+        }
+
+        //e.textContent = isd_element.text;
+
+    } else if (isd_element.kind === 'br') {
+
+        e = document.createElement('br');
+
+    }
+
+    if (!e) {
+
+        reportError(context.errorHandler, 'Error processing ISD element kind: ' + isd_element.kind);
+
+        return;
+
+    }
+
+    /* set language */
+
+    if (isd_element.lang) {
+
+        if (isd_element.kind === 'region' || isd_element.lang !== isd_parent.lang) {
+            e.lang = isd_element.lang;
+        }
+
+    }
+
+    /* add to parent */
+
+    dom_parent.appendChild(e);
+
+    /* override UA default margin */
+    /* TODO: should apply to <p> only */
+
+    e.style.margin = '0';
+
+    /* determine ipd and bpd */
+
+    if (isd_element.kind === 'region') {
+
+        var wdir = isd_element.styleAttrs[imscStyles.byName.writingMode.qname];
+
+        if (wdir === 'lrtb' || wdir === 'lr') {
+
+            context.ipd = 'lr';
+            context.bpd = 'tb';
+
+        } else if (wdir === 'rltb' || wdir === 'rl') {
+
+            context.ipd = 'rl';
+            context.bpd = 'tb';
+
+        } else if (wdir === 'tblr') {
+
+            context.ipd = 'tb';
+            context.bpd = 'lr';
+
+        } else if (wdir === 'tbrl' || wdir === 'tb') {
+
+            context.ipd = 'tb';
+            context.bpd = 'rl';
+
+        }
+
+    } else if (isd_element.kind === 'p' && context.bpd === 'tb') {
+
+        var pdir = isd_element.styleAttrs[imscStyles.byName.direction.qname];
+
+        context.ipd = pdir === 'ltr' ? 'lr' : 'rl';
+
+    }
+
+    /* tranform TTML styles to CSS styles */
+
+    for (var i = 0; i < STYLING_MAP_DEFS.length; i++) {
+
+        var sm = STYLING_MAP_DEFS[i];
+
+        var attr = isd_element.styleAttrs[sm.qname];
+
+        if (attr !== undefined && sm.map !== null) {
+
+            sm.map(context, e, isd_element, attr);
+
+        }
+
+    }
+
+    var proc_e = e;
+
+    /* do we have linePadding ? */
+
+    var lp = isd_element.styleAttrs[imscStyles.byName.linePadding.qname];
+
+    if (lp && (!lp.isZero())) {
+
+        var plength = lp.toUsedLength(context.w, context.h);
+
+
+        if (plength > 0) {
+
+            /* apply padding to the <p> so that line padding does not cause line wraps */
+
+            var padmeasure = Math.ceil(plength) + 'px';
+
+            if (context.bpd === 'tb') {
+
+                proc_e.style.paddingLeft = padmeasure;
+                proc_e.style.paddingRight = padmeasure;
+
+            } else {
+
+                proc_e.style.paddingTop = padmeasure;
+                proc_e.style.paddingBottom = padmeasure;
+
             }
 
-        return false;
+            context.lp = lp;
+        }
     }
 
-    function applyLinePadding(lineList, lp, context) {
+    // do we have multiRowAlign?
 
-        if (lineList === null) return;
+    var mra = isd_element.styleAttrs[imscStyles.byName.multiRowAlign.qname];
 
-        for (var i = 0; i < lineList.length; i++) {
+    if (mra && mra !== 'auto') {
 
-            var l = lineList[i].elements.length;
+        /* create inline block to handle multirowAlign */
 
-            var pospadpxlen = Math.ceil(lp) + "px";
+        var s = document.createElement('span');
 
-            var negpadpxlen = "-" + Math.ceil(lp) + "px";
+        s.style.display = 'inline-block';
 
-            if (l !== 0) {
+        s.style.textAlign = mra;
 
-                var se = lineList[i].elements[lineList[i].start_elem];
+        e.appendChild(s);
 
-                var ee = lineList[i].elements[lineList[i].end_elem];
+        proc_e = s;
 
-                if (se === ee) {
+        context.mra = mra;
 
-                    // Check to see if there's any background at all
-                    var elementBoundingRect = se.node.getBoundingClientRect();
+    }
+
+    /* do we have rubyReserve? */
+
+    var rr = isd_element.styleAttrs[imscStyles.byName.rubyReserve.qname];
+
+    if (rr && rr[0] !== 'none') {
+        context.rubyReserve = rr;
+    }
+
+
+    /* remember we are filling line gaps */
+
+    if (isd_element.styleAttrs[imscStyles.byName.fillLineGap.qname]) {
+        context.flg = true;
+    }
+
+
+    if (isd_element.kind === 'span' && isd_element.text) {
+
+        var te = isd_element.styleAttrs[imscStyles.byName.textEmphasis.qname];
+
+        if (te && te.style !== 'none') {
+
+            context.textEmphasis = true;
+
+        }
+
+        if (imscStyles.byName.textCombine.qname in isd_element.styleAttrs &&
+            isd_element.styleAttrs[imscStyles.byName.textCombine.qname] === 'all') {
+
+            /* ignore tate-chu-yoku since line break cannot happen within */
+            e.textContent = isd_element.text;
+
+            if (te) {
+
+                applyTextEmphasis(context, e, isd_element, te);
+
+            }
+            
+
+        } else {
+
+            // wrap characters in spans to find the line wrap locations
+
+            var cbuf = '';
+
+            for (var j = 0; j < isd_element.text.length; j++) {
+
+                cbuf += isd_element.text.charAt(j);
+
+                var cc = isd_element.text.charCodeAt(j);
+
+                if (cc < 0xD800 || cc > 0xDBFF || j === isd_element.text.length - 1) {
+
+                    /* wrap the character(s) in a span unless it is a high surrogate */
+
+                    var span = document.createElement('span');
+
+                    span.textContent = cbuf;
+
+                    /* apply textEmphasis */
+
+                    if (te) {
+
+                        applyTextEmphasis(context, span, isd_element, te);
+
+                    }
                     
-                    if (elementBoundingRect.width == 0 || elementBoundingRect.height == 0) {
 
-                        // There's no background on this line, move on.
-                        continue;
+                    e.appendChild(span);
 
-                    }
+                    cbuf = '';
 
-                }
-
-                // Start element
-                if (context.ipd === "lr") {
-
-                    se.node.style.marginLeft = negpadpxlen;
-                    se.node.style.paddingLeft = pospadpxlen;
-
-                } else if (context.ipd === "rl") {
-
-                    se.node.style.paddingRight = pospadpxlen;
-                    se.node.style.marginRight = negpadpxlen;
-
-                } else if (context.ipd === "tb") {
-
-                    se.node.style.paddingTop = pospadpxlen;
-                    se.node.style.marginTop = negpadpxlen;
-
-                }
-
-                // End element
-                if (context.ipd === "lr") {
-
-                    ee.node.style.marginRight = negpadpxlen;
-                    ee.node.style.paddingRight = pospadpxlen;
-
-                } else if (context.ipd === "rl") {
-
-                    ee.node.style.paddingLeft = pospadpxlen;
-                    ee.node.style.marginLeft = negpadpxlen;
-
-                } else if (context.ipd === "tb") {
-
-                    ee.node.style.paddingBottom = pospadpxlen;
-                    ee.node.style.marginBottom = negpadpxlen;
-
+                    //For the sake of merging these back together, record what isd element generated it.
+                    span._isd_element = isd_element;
                 }
 
             }
 
         }
-
     }
 
-    function applyMultiRowAlign(lineList) {
+    /* process the children of the ISD element */
 
-        /* apply an explicit br to all but the last line */
+    if ('contents' in isd_element) {
 
-        for (var i = 0; i < lineList.length - 1; i++) {
+        for (var k = 0; k < isd_element.contents.length; k++) {
 
-            var l = lineList[i].elements.length;
-
-            if (l !== 0 && lineList[i].br === false) {
-                var br = document.createElement("br");
-
-                var lastnode = lineList[i].elements[l - 1].node;
-
-                lastnode.parentElement.insertBefore(br, lastnode.nextSibling);
-            }
+            processElement(context, proc_e, isd_element.contents[k], isd_element);
 
         }
 
     }
 
-    function applyTextEmphasisOutside(lineList, context) {
+    /* list of lines */
 
-        /* supports "outside" only */
+    var linelist = [];
 
-        for (var i = 0; i < lineList.length; i++) {
 
-            for (var j = 0; j < lineList[i].te.length; j++) {
+    /* paragraph processing */
+    /* TODO: linePadding only supported for horizontal scripts */
 
-                /* skip if position already set */
+    if (isd_element.kind === 'p') {
 
-                if (lineList[i].te[j].style[TEXTEMPHASISPOSITION_PROP] &&
-                    lineList[i].te[j].style[TEXTEMPHASISPOSITION_PROP] !== "none")
+        constructLineList(context, proc_e, linelist, null);
+
+        /* apply rubyReserve */
+
+        if (context.rubyReserve) {
+
+            applyRubyReserve(linelist, context);
+
+            context.rubyReserve = null;
+
+        }
+
+        /* apply tts:rubyPosition="outside" */
+
+        if (context.ruby || context.rubyReserve) {
+
+            applyRubyPosition(linelist, context);
+
+            context.ruby = null;
+
+        }
+
+        /* apply text emphasis "outside" position */
+
+        if (context.textEmphasis) {
+
+            applyTextEmphasisOutside(linelist, context);
+
+            context.textEmphasis = null;
+
+        }
+
+        /* insert line breaks for multirowalign */
+
+        if (context.mra) {
+
+            applyMultiRowAlign(linelist);
+
+            context.mra = null;
+
+        }
+
+        /* add linepadding */
+
+        if (context.lp) {
+
+            applyLinePadding(linelist, context.lp.toUsedLength(context.w, context.h), context);
+
+            context.lp = null;
+
+        }
+
+        mergeSpans(linelist); // The earlier we can do this the less processing there will be.
+
+        /* fill line gaps linepadding */
+
+        if (context.flg) {
+
+            var par_edges = rect2edges(proc_e.getBoundingClientRect(), context);
+
+            applyFillLineGap(linelist, par_edges.before, par_edges.after, context, proc_e);
+
+            context.flg = null;
+
+        }
+
+    }
+
+
+    /* region processing */
+
+    if (isd_element.kind === 'region') {
+
+        /* perform roll up if needed */
+        if ((context.bpd === 'tb') &&
+            context.enableRollUp &&
+            isd_element.contents.length > 0 &&
+            isd_element.styleAttrs[imscStyles.byName.displayAlign.qname] === 'after') {
+
+            /* build line list */
+            constructLineList(context, proc_e, linelist, null);
+
+            /* horrible hack, perhaps default region id should be underscore everywhere? */
+
+            var rid = isd_element.id === '' ? '_' : isd_element.id;
+
+            var rb = new RegionPBuffer(rid, linelist);
+
+            context.currentISDState[rb.id] = rb;
+
+            if (context.previousISDState &&
+                rb.id in context.previousISDState &&
+                context.previousISDState[rb.id].plist.length > 0 &&
+                rb.plist.length > 1 &&
+                rb.plist[rb.plist.length - 2].text ===
+                context.previousISDState[rb.id].plist[context.previousISDState[rb.id].plist.length - 1].text) {
+
+                var body_elem = e.firstElementChild;
+
+                var h = rb.plist[rb.plist.length - 1].after - rb.plist[rb.plist.length - 1].before;
+
+                body_elem.style.bottom = '-' + h + 'px';
+                body_elem.style.transition = 'transform 0.4s';
+                body_elem.style.position = 'relative';
+                body_elem.style.transform = 'translateY(-' + h + 'px)';
+
+            }
+
+        }
+    }
+}
+
+function mergeSpans(lineList) {
+
+    for (var i = 0; i < lineList.length; i++) {
+
+        var line = lineList[i];
+
+        for (var j = 1; j < line.elements.length;) {
+
+            var previous = line.elements[j - 1];
+            var span = line.elements[j];
+
+            if (spanMerge(previous.node, span.node)) {
+
+                //removed from DOM by spanMerge(), remove from the list too.
+                line.elements.splice(j, 1);
+                continue;
+
+            } else {
+
+                j++;
+
+            }
+
+        }
+    }
+
+    // Copy backgroundColor to each span so that fillLineGap will apply padding to elements with the right background
+    var thisNode, ancestorBackgroundColor;
+    var clearTheseBackgrounds = [];
+
+    for (var l = 0; l < lineList.length; l++) {
+
+        for (var el = 0; el < lineList[l].elements.length; el++) {
+
+            thisNode = lineList[l].elements[el].node;
+            ancestorBackgroundColor = getSpanAncestorColor(thisNode, clearTheseBackgrounds, false);
+
+            if (ancestorBackgroundColor) {
+
+                thisNode.style.backgroundColor = ancestorBackgroundColor;
+
+            }
+        }
+    }
+
+    for (var bi = 0; bi < clearTheseBackgrounds.length; bi++) {
+
+        clearTheseBackgrounds[bi].style.backgroundColor = '';
+
+    }
+}
+
+function getSpanAncestorColor(element, ancestorList, isAncestor) {
+
+    if (element.style.backgroundColor) {
+
+        if (isAncestor && !ancestorList.includes(element)) {
+
+            ancestorList.push(element);
+
+        }
+        return element.style.backgroundColor;
+
+    } else {
+
+        if (element.parentElement.nodeName === 'SPAN') {
+
+            return getSpanAncestorColor(element.parentElement, ancestorList, true);
+
+        }
+
+    }
+
+    return undefined;
+}
+
+function spanMerge(first, second) {
+
+    if (first.tagName === 'SPAN' &&
+        second.tagName === 'SPAN' &&
+        first._isd_element === second._isd_element) {
+
+        first.textContent += second.textContent;
+
+        for (var i = 0; i < second.style.length; i++) {
+
+            var styleName = second.style[i];
+            if (styleName.indexOf('border') >= 0 ||
+                styleName.indexOf('padding') >= 0 ||
+                styleName.indexOf('margin') >= 0) {
+
+                first.style[styleName] = second.style[styleName];
+
+            }
+        }
+
+        second.parentElement.removeChild(second);
+
+        return true;
+    }
+
+    return false;
+}
+
+function applyLinePadding(lineList, lp, context) {
+
+    if (lineList === null) return;
+
+    for (var i = 0; i < lineList.length; i++) {
+
+        var l = lineList[i].elements.length;
+
+        var pospadpxlen = Math.ceil(lp) + 'px';
+
+        var negpadpxlen = '-' + Math.ceil(lp) + 'px';
+
+        if (l !== 0) {
+
+            var se = lineList[i].elements[lineList[i].start_elem];
+
+            var ee = lineList[i].elements[lineList[i].end_elem];
+
+            if (se === ee) {
+
+                // Check to see if there's any background at all
+                var elementBoundingRect = se.node.getBoundingClientRect();
+
+                if (elementBoundingRect.width == 0 || elementBoundingRect.height == 0) {
+
+                    // There's no background on this line, move on.
                     continue;
 
-                var pos;
+                }
 
-                if (context.bpd === "tb") {
+            }
 
-                    pos = (i === 0) ? "left over" : "left under";
+            // Start element
+            if (context.ipd === 'lr') {
 
+                se.node.style.marginLeft = negpadpxlen;
+                se.node.style.paddingLeft = pospadpxlen;
+
+            } else if (context.ipd === 'rl') {
+
+                se.node.style.paddingRight = pospadpxlen;
+                se.node.style.marginRight = negpadpxlen;
+
+            } else if (context.ipd === 'tb') {
+
+                se.node.style.paddingTop = pospadpxlen;
+                se.node.style.marginTop = negpadpxlen;
+
+            }
+
+            // End element
+            if (context.ipd === 'lr') {
+
+                ee.node.style.marginRight = negpadpxlen;
+                ee.node.style.paddingRight = pospadpxlen;
+
+            } else if (context.ipd === 'rl') {
+
+                ee.node.style.paddingLeft = pospadpxlen;
+                ee.node.style.marginLeft = negpadpxlen;
+
+            } else if (context.ipd === 'tb') {
+
+                ee.node.style.paddingBottom = pospadpxlen;
+                ee.node.style.marginBottom = negpadpxlen;
+
+            }
+
+        }
+
+    }
+
+}
+
+function applyMultiRowAlign(lineList) {
+
+    /* apply an explicit br to all but the last line */
+
+    for (var i = 0; i < lineList.length - 1; i++) {
+
+        var l = lineList[i].elements.length;
+
+        if (l !== 0 && lineList[i].br === false) {
+            var br = document.createElement('br');
+
+            var lastnode = lineList[i].elements[l - 1].node;
+
+            lastnode.parentElement.insertBefore(br, lastnode.nextSibling);
+        }
+
+    }
+
+}
+
+function applyTextEmphasisOutside(lineList, context) {
+
+    /* supports "outside" only */
+
+    for (var i = 0; i < lineList.length; i++) {
+
+        for (var j = 0; j < lineList[i].te.length; j++) {
+
+            /* skip if position already set */
+
+            if (lineList[i].te[j].style[TEXTEMPHASISPOSITION_PROP] &&
+                lineList[i].te[j].style[TEXTEMPHASISPOSITION_PROP] !== 'none')
+                continue;
+
+            var pos;
+
+            if (context.bpd === 'tb') {
+
+                pos = (i === 0) ? 'left over' : 'left under';
+
+
+            } else {
+
+                if (context.bpd === 'rl') {
+
+                    pos = (i === 0) ? 'right under' : 'left under';
 
                 } else {
 
-                    if (context.bpd === "rl") {
+                    pos = (i === 0) ? 'left under' : 'right under';
 
-                        pos = (i === 0) ? "right under" : "left under";
+                }
 
-                    } else {
+            }
 
-                        pos = (i === 0) ? "left under" : "right under";
+            lineList[i].te[j].style[TEXTEMPHASISPOSITION_PROP] = pos;
+
+        }
+
+    }
+
+}
+
+function applyRubyPosition(lineList, context) {
+
+    for (var i = 0; i < lineList.length; i++) {
+
+        for (var j = 0; j < lineList[i].rbc.length; j++) {
+
+            /* skip if ruby-position already set */
+
+            if (lineList[i].rbc[j].style[RUBYPOSITION_PROP])
+                continue;
+
+            var pos;
+
+            if (RUBYPOSITION_ISWK) {
+
+                /* WebKit exception */
+
+                pos = (i === 0) ? 'before' : 'after';
+
+            } else if (context.bpd === 'tb') {
+
+                pos = (i === 0) ? 'over' : 'under';
+
+
+            } else {
+
+                if (context.bpd === 'rl') {
+
+                    pos = (i === 0) ? 'over' : 'under';
+
+                } else {
+
+                    pos = (i === 0) ? 'under' : 'over';
+
+                }
+
+            }
+
+            lineList[i].rbc[j].style[RUBYPOSITION_PROP] = pos;
+
+        }
+
+    }
+
+}
+
+function applyRubyReserve(lineList, context) {
+
+    for (var i = 0; i < lineList.length; i++) {
+
+        var ruby = document.createElement('ruby');
+
+        var rb = document.createElement('rb');
+        rb.textContent = '\u200B';
+
+        ruby.appendChild(rb);
+
+        var rt1;
+        var rt2;
+
+        var fs = context.rubyReserve[1].toUsedLength(context.w, context.h) + 'px';
+
+        if (context.rubyReserve[0] === 'both' || (context.rubyReserve[0] === 'outside' && lineList.length == 1)) {
+
+            rt1 = document.createElement('rtc');
+            rt1.style[RUBYPOSITION_PROP] = RUBYPOSITION_ISWK ? 'after' : 'under';
+            rt1.textContent = '\u200B';
+            rt1.style.fontSize = fs;
+
+            rt2 = document.createElement('rtc');
+            rt2.style[RUBYPOSITION_PROP] = RUBYPOSITION_ISWK ? 'before' : 'over';
+            rt2.textContent = '\u200B';
+            rt2.style.fontSize = fs;
+
+            ruby.appendChild(rt1);
+            ruby.appendChild(rt2);
+
+        } else {
+
+            rt1 = document.createElement('rtc');
+            rt1.textContent = '\u200B';
+            rt1.style.fontSize = fs;
+
+            var pos;
+
+            if (context.rubyReserve[0] === 'after' || (context.rubyReserve[0] === 'outside' && i > 0)) {
+
+                pos = RUBYPOSITION_ISWK ? 'after' : ((context.bpd === 'tb' || context.bpd === 'rl') ? 'under' : 'over');
+
+            } else {
+
+                pos = RUBYPOSITION_ISWK ? 'before' : ((context.bpd === 'tb' || context.bpd === 'rl') ? 'over' : 'under');
+
+            }
+
+            rt1.style[RUBYPOSITION_PROP] = pos;
+
+            ruby.appendChild(rt1);
+
+        }
+
+        /* add in front of the first ruby element of the line, if it exists */
+
+        var sib = null;
+
+        for (var j = 0; j < lineList[i].rbc.length; j++) {
+
+            if (lineList[i].rbc[j].localName === 'ruby') {
+
+                sib = lineList[i].rbc[j];
+
+                /* copy specified style properties from the sibling ruby container */
+
+                for (var k = 0; k < sib.style.length; k++) {
+
+                    ruby.style.setProperty(sib.style.item(k), sib.style.getPropertyValue(sib.style.item(k)));
+
+                }
+
+                break;
+            }
+
+        }
+
+        /* otherwise add before first span */
+
+        sib = sib || lineList[i].elements[0].node;
+
+        sib.parentElement.insertBefore(ruby, sib);
+
+    }
+
+}
+
+function applyFillLineGap(lineList, par_before, par_after, context) { //, element) {
+
+    /* positive for BPD = lr and tb, negative for BPD = rl */
+    var s = Math.sign(par_after - par_before);
+
+    for (var i = 0; i <= lineList.length; i++) {
+
+        /* compute frontier between lines */
+
+        var frontier;
+
+        if (i === 0) {
+
+            frontier = Math.round(par_before);
+
+        } else if (i === lineList.length) {
+
+            frontier = Math.round(par_after);
+
+        } else {
+
+            frontier = Math.round((lineList[i - 1].after + lineList[i].before) / 2);
+
+        }
+
+        var padding;
+        var l, thisNode;
+
+        /* before line */
+        if (i > 0) {
+
+            if (lineList[i - 1]) {
+
+                for (l = 0; l < lineList[i - 1].elements.length; l++) {
+
+                    thisNode = lineList[i - 1].elements[l];
+                    padding = s * (frontier - thisNode.after) + 'px';
+
+                    if (context.bpd === 'lr') {
+
+                        thisNode.node.style.paddingRight = padding;
+
+                    } else if (context.bpd === 'rl') {
+
+                        thisNode.node.style.paddingLeft = padding;
+
+                    } else if (context.bpd === 'tb') {
+
+                        thisNode.node.style.paddingBottom = padding;
 
                     }
 
                 }
 
-                lineList[i].te[j].style[TEXTEMPHASISPOSITION_PROP] = pos;
+            }
 
+        }
+
+        /* after line */
+        if (i < lineList.length) {
+
+            for (l = 0; l < lineList[i].elements.length; l++) {
+
+                thisNode = lineList[i].elements[l];
+                padding = s * (thisNode.before - frontier) + 'px';
+
+                if (context.bpd === 'lr') {
+
+                    thisNode.node.style.paddingLeft = padding;
+
+                } else if (context.bpd === 'rl') {
+
+                    thisNode.node.style.paddingRight = padding;
+
+                } else if (context.bpd === 'tb') {
+
+                    thisNode.node.style.paddingTop = padding;
+
+                }
             }
 
         }
 
     }
 
-    function applyRubyPosition(lineList, context) {
+}
 
-        for (var i = 0; i < lineList.length; i++) {
+function RegionPBuffer(id, lineList) {
 
-            for (var j = 0; j < lineList[i].rbc.length; j++) {
+    this.id = id;
 
-                /* skip if ruby-position already set */
+    this.plist = lineList;
 
-                if (lineList[i].rbc[j].style[RUBYPOSITION_PROP])
-                    continue;
+}
+
+function rect2edges(rect, context) {
+
+    var edges = {before: null, after: null, start: null, end: null};
+
+    if (context.bpd === 'tb') {
+
+        edges.before = rect.top;
+        edges.after = rect.bottom;
+
+        if (context.ipd === 'lr') {
+
+            edges.start = rect.left;
+            edges.end = rect.right;
+
+        } else {
+
+            edges.start = rect.right;
+            edges.end = rect.left;
+        }
+
+    } else if (context.bpd === 'lr') {
+
+        edges.before = rect.left;
+        edges.after = rect.right;
+        edges.start = rect.top;
+        edges.end = rect.bottom;
+
+    } else if (context.bpd === 'rl') {
+
+        edges.before = rect.right;
+        edges.after = rect.left;
+        edges.start = rect.top;
+        edges.end = rect.bottom;
+
+    }
+
+    return edges;
+
+}
+
+function constructLineList(context, element, llist, bgcolor) {
+
+    if (element.localName === 'rt' || element.localName === 'rtc') {
+
+        /* skip ruby annotations */
+
+        return;
+
+    }
+
+    var curbgcolor = element.style.backgroundColor || bgcolor;
+
+    if (element.childElementCount === 0) {
+
+        if (element.localName === 'span' || element.localName === 'rb') {
+
+            var r = element.getBoundingClientRect();
+
+            var edges = rect2edges(r, context);
+
+            if (llist.length === 0 ||
+                (!isSameLine(edges.before, edges.after, llist[llist.length - 1].before, llist[llist.length - 1].after))
+            ) {
+                llist.push({
+                    before: edges.before,
+                    after: edges.after,
+                    start: edges.start,
+                    end: edges.end,
+                    start_elem: 0,
+                    end_elem: 0,
+                    elements: [],
+                    rbc: [],
+                    te: [],
+                    text: '',
+                    br: false
+                });
+
+            } else {
+
+                /* positive for BPD = lr and tb, negative for BPD = rl */
+                var bpd_dir = Math.sign(edges.after - edges.before);
+
+                /* positive for IPD = lr and tb, negative for IPD = rl */
+                var ipd_dir = Math.sign(edges.end - edges.start);
+
+                /* check if the line height has increased */
+
+                if (bpd_dir * (edges.before - llist[llist.length - 1].before) < 0) {
+                    llist[llist.length - 1].before = edges.before;
+                }
+
+                if (bpd_dir * (edges.after - llist[llist.length - 1].after) > 0) {
+                    llist[llist.length - 1].after = edges.after;
+                }
+
+                if (ipd_dir * (edges.start - llist[llist.length - 1].start) < 0) {
+                    llist[llist.length - 1].start = edges.start;
+                    llist[llist.length - 1].start_elem = llist[llist.length - 1].elements.length;
+                }
+
+                if (ipd_dir * (edges.end - llist[llist.length - 1].end) > 0) {
+                    llist[llist.length - 1].end = edges.end;
+                    llist[llist.length - 1].end_elem = llist[llist.length - 1].elements.length;
+                }
+
+            }
+
+            llist[llist.length - 1].text += element.textContent;
+
+            llist[llist.length - 1].elements.push(
+                {
+                    node: element,
+                    bgcolor: curbgcolor,
+                    before: edges.before,
+                    after: edges.after
+                }
+            );
+
+        } else if (element.localName === 'br' && llist.length !== 0) {
+
+            llist[llist.length - 1].br = true;
+
+        }
+
+    } else {
+
+        var child = element.firstChild;
+
+        while (child) {
+
+            if (child.nodeType === Node.ELEMENT_NODE) {
+
+                constructLineList(context, child, llist, curbgcolor);
+
+                if (child.localName === 'ruby' || child.localName === 'rtc') {
+
+                    /* remember non-empty ruby and rtc elements so that tts:rubyPosition can be applied */
+
+                    if (llist.length > 0) {
+
+                        llist[llist.length - 1].rbc.push(child);
+
+                    }
+
+                } else if (child.localName === 'span' &&
+                    child.style[TEXTEMPHASISSTYLE_PROP] &&
+                    child.style[TEXTEMPHASISSTYLE_PROP] !== 'none') {
+
+                    /* remember non-empty span elements with textEmphasis */
+
+                    if (llist.length > 0) {
+
+                        llist[llist.length - 1].te.push(child);
+
+                    }
+
+                }
+
+
+            }
+
+            child = child.nextSibling;
+        }
+    }
+
+}
+
+function isSameLine(before1, after1, before2, after2) {
+
+    return ((after1 < after2) && (before1 > before2)) || ((after2 <= after1) && (before2 >= before1));
+
+}
+
+function applyTextEmphasis(context, dom_element, isd_element, attr) {
+
+    /* ignore color (not used in IMSC 1.1) */
+
+    if (attr.style === 'none') {
+
+        /* text-emphasis is not inherited and the default is none, so nothing to do */
+
+        return;
+
+    } else if (attr.style === 'auto') {
+
+        dom_element.style[TEXTEMPHASISSTYLE_PROP] = 'filled';
+
+    } else {
+
+        dom_element.style[TEXTEMPHASISSTYLE_PROP] = attr.style + ' ' + attr.symbol;
+    }
+
+    /* ignore "outside" position (set in postprocessing) */
+
+    if (attr.position === 'before' || attr.position === 'after') {
+
+        var pos;
+
+        if (context.bpd === 'tb') {
+
+            pos = (attr.position === 'before') ? 'left over' : 'left under';
+
+
+        } else {
+
+            if (context.bpd === 'rl') {
+
+                pos = (attr.position === 'before') ? 'right under' : 'left under';
+
+            } else {
+
+                pos = (attr.position === 'before') ? 'left under' : 'right under';
+
+            }
+
+        }
+
+        dom_element.style[TEXTEMPHASISPOSITION_PROP] = pos;
+    }
+}
+
+function HTMLStylingMapDefinition(qName, mapFunc) {
+    this.qname = qName;
+    this.map = mapFunc;
+}
+
+var STYLING_MAP_DEFS = [
+
+    new HTMLStylingMapDefinition(
+        'http://www.w3.org/ns/ttml#styling backgroundColor',
+        function (context, dom_element, isd_element, attr) {
+
+            /* skip if transparent */
+            if (attr[3] === 0)
+                return;
+
+            dom_element.style.backgroundColor = 'rgba(' +
+                attr[0].toString() + ',' +
+                attr[1].toString() + ',' +
+                attr[2].toString() + ',' +
+                (attr[3] / 255).toString() +
+                ')';
+        }
+    ),
+    new HTMLStylingMapDefinition(
+        'http://www.w3.org/ns/ttml#styling color',
+        function (context, dom_element, isd_element, attr) {
+            dom_element.style.color = 'rgba(' +
+                attr[0].toString() + ',' +
+                attr[1].toString() + ',' +
+                attr[2].toString() + ',' +
+                (attr[3] / 255).toString() +
+                ')';
+        }
+    ),
+    new HTMLStylingMapDefinition(
+        'http://www.w3.org/ns/ttml#styling direction',
+        function (context, dom_element, isd_element, attr) {
+
+            dom_element.style.direction = attr;
+
+        }
+    ),
+    new HTMLStylingMapDefinition(
+        'http://www.w3.org/ns/ttml#styling display',
+        function () { //function (context, dom_element, isd_element, attr) {
+        }
+    ),
+    new HTMLStylingMapDefinition(
+        'http://www.w3.org/ns/ttml#styling displayAlign',
+        function (context, dom_element, isd_element, attr) {
+
+            /* see https://css-tricks.com/snippets/css/a-guide-to-flexbox/ */
+
+            /* TODO: is this affected by writing direction? */
+
+            dom_element.style.display = 'flex';
+            dom_element.style.flexDirection = 'column';
+
+
+            if (attr === 'before') {
+
+                dom_element.style.justifyContent = 'flex-start';
+
+            } else if (attr === 'center') {
+
+                dom_element.style.justifyContent = 'center';
+
+            } else if (attr === 'after') {
+
+                dom_element.style.justifyContent = 'flex-end';
+            }
+
+        }
+    ),
+    new HTMLStylingMapDefinition(
+        'http://www.w3.org/ns/ttml#styling extent',
+        function (context, dom_element, isd_element, attr) {
+            /* TODO: this is super ugly */
+
+            context.regionH = attr.h.toUsedLength(context.w, context.h);
+            context.regionW = attr.w.toUsedLength(context.w, context.h);
+
+            /*
+             * CSS height/width are measured against the content rectangle,
+             * whereas TTML height/width include padding
+             */
+
+            var hdelta = 0;
+            var wdelta = 0;
+
+            var p = isd_element.styleAttrs['http://www.w3.org/ns/ttml#styling padding'];
+
+            if (!p) {
+
+                /* error */
+
+            } else {
+
+                hdelta = p[0].toUsedLength(context.w, context.h) + p[2].toUsedLength(context.w, context.h);
+                wdelta = p[1].toUsedLength(context.w, context.h) + p[3].toUsedLength(context.w, context.h);
+
+            }
+
+            dom_element.style.height = (context.regionH - hdelta) + 'px';
+            dom_element.style.width = (context.regionW - wdelta) + 'px';
+
+        }
+    ),
+    new HTMLStylingMapDefinition(
+        'http://www.w3.org/ns/ttml#styling fontFamily',
+        function (context, dom_element, isd_element, attr) {
+
+            var rslt = [];
+
+            /* per IMSC1 */
+
+            for (var i = 0; i < attr.length; i++) {
+
+                if (attr[i] === 'monospaceSerif') {
+
+                    rslt.push('Courier New');
+                    rslt.push('"Liberation Mono"');
+                    rslt.push('Courier');
+                    rslt.push('monospace');
+
+                } else if (attr[i] === 'proportionalSansSerif') {
+
+                    rslt.push('Arial');
+                    rslt.push('Helvetica');
+                    rslt.push('"Liberation Sans"');
+                    rslt.push('sans-serif');
+
+                } else if (attr[i] === 'monospace') {
+
+                    rslt.push('monospace');
+
+                } else if (attr[i] === 'sansSerif') {
+
+                    rslt.push('sans-serif');
+
+                } else if (attr[i] === 'serif') {
+
+                    rslt.push('serif');
+
+                } else if (attr[i] === 'monospaceSansSerif') {
+
+                    rslt.push('Consolas');
+                    rslt.push('monospace');
+
+                } else if (attr[i] === 'proportionalSerif') {
+
+                    rslt.push('serif');
+
+                } else {
+
+                    rslt.push(attr[i]);
+
+                }
+
+            }
+
+            // prune later duplicates we may have inserted
+            if (rslt.length > 0) {
+
+                var unique = [rslt[0]];
+
+                for (var fi = 1; fi < rslt.length; fi++) {
+
+                    if (unique.indexOf(rslt[fi]) == -1) {
+
+                        unique.push(rslt[fi]);
+
+                    }
+                }
+
+                rslt = unique;
+            }
+
+            dom_element.style.fontFamily = rslt.join(',');
+        }
+    ),
+
+    new HTMLStylingMapDefinition(
+        'http://www.w3.org/ns/ttml#styling shear',
+        function (context, dom_element, isd_element, attr) {
+
+            /* return immediately if tts:shear is 0% since CSS transforms are not inherited*/
+
+            if (attr === 0)
+                return;
+
+            var angle = attr * -0.9;
+
+            /* context.bpd is needed since writing mode is not inherited and sets the inline progression */
+
+            if (context.bpd === 'tb') {
+
+                dom_element.style.transform = 'skewX(' + angle + 'deg)';
+
+            } else {
+
+                dom_element.style.transform = 'skewY(' + angle + 'deg)';
+
+            }
+
+        }
+    ),
+
+    new HTMLStylingMapDefinition(
+        'http://www.w3.org/ns/ttml#styling fontSize',
+        function (context, dom_element, isd_element, attr) {
+            dom_element.style.fontSize = attr.toUsedLength(context.w, context.h) + 'px';
+        }
+    ),
+
+    new HTMLStylingMapDefinition(
+        'http://www.w3.org/ns/ttml#styling fontStyle',
+        function (context, dom_element, isd_element, attr) {
+            dom_element.style.fontStyle = attr;
+        }
+    ),
+    new HTMLStylingMapDefinition(
+        'http://www.w3.org/ns/ttml#styling fontWeight',
+        function (context, dom_element, isd_element, attr) {
+            dom_element.style.fontWeight = attr;
+        }
+    ),
+    new HTMLStylingMapDefinition(
+        'http://www.w3.org/ns/ttml#styling lineHeight',
+        function (context, dom_element, isd_element, attr) {
+            if (attr === 'normal') {
+
+                dom_element.style.lineHeight = 'normal';
+
+            } else {
+
+                dom_element.style.lineHeight = attr.toUsedLength(context.w, context.h) + 'px';
+            }
+        }
+    ),
+    new HTMLStylingMapDefinition(
+        'http://www.w3.org/ns/ttml#styling opacity',
+        function (context, dom_element, isd_element, attr) {
+            dom_element.style.opacity = attr;
+        }
+    ),
+    new HTMLStylingMapDefinition(
+        'http://www.w3.org/ns/ttml#styling origin',
+        function (context, dom_element, isd_element, attr) {
+            dom_element.style.top = attr.h.toUsedLength(context.w, context.h) + 'px';
+            dom_element.style.left = attr.w.toUsedLength(context.w, context.h) + 'px';
+        }
+    ),
+    new HTMLStylingMapDefinition(
+        'http://www.w3.org/ns/ttml#styling overflow',
+        function (context, dom_element, isd_element, attr) {
+            dom_element.style.overflow = attr;
+        }
+    ),
+    new HTMLStylingMapDefinition(
+        'http://www.w3.org/ns/ttml#styling padding',
+        function (context, dom_element, isd_element, attr) {
+
+            /* attr: top,left,bottom,right*/
+
+            /* style: top right bottom left*/
+
+            var rslt = [];
+
+            rslt[0] = attr[0].toUsedLength(context.w, context.h) + 'px';
+            rslt[1] = attr[3].toUsedLength(context.w, context.h) + 'px';
+            rslt[2] = attr[2].toUsedLength(context.w, context.h) + 'px';
+            rslt[3] = attr[1].toUsedLength(context.w, context.h) + 'px';
+
+            dom_element.style.padding = rslt.join(' ');
+        }
+    ),
+    new HTMLStylingMapDefinition(
+        'http://www.w3.org/ns/ttml#styling position',
+        function (context, dom_element, isd_element, attr) {
+            dom_element.style.top = attr.h.toUsedLength(context.w, context.h) + 'px';
+            dom_element.style.left = attr.w.toUsedLength(context.w, context.h) + 'px';
+        }
+    ),
+    new HTMLStylingMapDefinition(
+        'http://www.w3.org/ns/ttml#styling rubyAlign',
+        function (context, dom_element, isd_element, attr) {
+            dom_element.style.rubyAlign = attr === 'spaceAround' ? 'space-around' : 'center';
+        }
+    ),
+    new HTMLStylingMapDefinition(
+        'http://www.w3.org/ns/ttml#styling rubyPosition',
+        function (context, dom_element, isd_element, attr) {
+
+            /* skip if "outside", which is handled by applyRubyPosition() */
+
+            if (attr === 'before' || attr === 'after') {
 
                 var pos;
 
@@ -841,1005 +1581,255 @@
 
                     /* WebKit exception */
 
-                    pos = (i === 0) ? "before" : "after";
+                    pos = attr;
 
-                } else if (context.bpd === "tb") {
+                } else if (context.bpd === 'tb') {
 
-                    pos = (i === 0) ? "over" : "under";
+                    pos = (attr === 'before') ? 'over' : 'under';
 
 
                 } else {
 
-                    if (context.bpd === "rl") {
+                    if (context.bpd === 'rl') {
 
-                        pos = (i === 0) ? "over" : "under";
+                        pos = (attr === 'before') ? 'over' : 'under';
 
                     } else {
 
-                        pos = (i === 0) ? "under" : "over";
+                        pos = (attr === 'before') ? 'under' : 'over';
 
                     }
 
                 }
 
-                lineList[i].rbc[j].style[RUBYPOSITION_PROP] = pos;
+                /* apply position to the parent dom_element, i.e. ruby or rtc */
 
+                dom_element.parentElement.style[RUBYPOSITION_PROP] = pos;
             }
-
         }
+    ),
+    new HTMLStylingMapDefinition(
+        'http://www.w3.org/ns/ttml#styling showBackground',
+        null
+    ),
+    new HTMLStylingMapDefinition(
+        'http://www.w3.org/ns/ttml#styling textAlign',
+        function (context, dom_element, isd_element, attr) {
 
-    }
+            var ta;
 
-    function applyRubyReserve(lineList, context) {
+            /* handle UAs that do not understand start or end */
 
-        for (var i = 0; i < lineList.length; i++) {
+            if (attr === 'start') {
 
-            var ruby = document.createElement("ruby");
+                ta = (context.ipd === 'rl') ? 'right' : 'left';
 
-            var rb = document.createElement("rb");
-            rb.textContent = "\u200B";
+            } else if (attr === 'end') {
 
-            ruby.appendChild(rb);
-
-            var rt1;
-            var rt2;
-
-            var fs = context.rubyReserve[1].toUsedLength(context.w, context.h) + "px";
-
-            if (context.rubyReserve[0] === "both" || (context.rubyReserve[0] === "outside" && lineList.length == 1)) {
-
-                rt1 = document.createElement("rtc");
-                rt1.style[RUBYPOSITION_PROP] = RUBYPOSITION_ISWK ? "after" : "under";
-                rt1.textContent = "\u200B";
-                rt1.style.fontSize = fs;
-
-                rt2 = document.createElement("rtc");
-                rt2.style[RUBYPOSITION_PROP] = RUBYPOSITION_ISWK ? "before" : "over";
-                rt2.textContent = "\u200B";
-                rt2.style.fontSize = fs;
-
-                ruby.appendChild(rt1);
-                ruby.appendChild(rt2);
+                ta = (context.ipd === 'rl') ? 'left' : 'right';
 
             } else {
 
-                rt1 = document.createElement("rtc");
-                rt1.textContent = "\u200B";
-                rt1.style.fontSize = fs;
-
-                var pos;
-
-                if (context.rubyReserve[0] === "after" || (context.rubyReserve[0] === "outside" && i > 0)) {
-
-                    pos = RUBYPOSITION_ISWK ? "after" : ((context.bpd === "tb" || context.bpd === "rl") ? "under" : "over");
-
-                } else {
-
-                    pos = RUBYPOSITION_ISWK ? "before" : ((context.bpd === "tb" || context.bpd === "rl") ? "over" : "under");
-
-                }
-
-                rt1.style[RUBYPOSITION_PROP] = pos;
-
-                ruby.appendChild(rt1);
+                ta = attr;
 
             }
 
-            /* add in front of the first ruby element of the line, if it exists */
-
-            var sib = null;
-
-            for (var j = 0; j < lineList[i].rbc.length; j++) {
-
-                if (lineList[i].rbc[j].localName === 'ruby') {
-
-                    sib = lineList[i].rbc[j];
-
-                    /* copy specified style properties from the sibling ruby container */
-                    
-                    for (var k = 0; k < sib.style.length; k++) {
-
-                        ruby.style.setProperty(sib.style.item(k), sib.style.getPropertyValue(sib.style.item(k)));
-
-                    }
-
-                    break;
-                }
-
-            }
-
-            /* otherwise add before first span */
-
-            sib = sib || lineList[i].elements[0].node;
-
-            sib.parentElement.insertBefore(ruby, sib);
+            dom_element.style.textAlign = ta;
 
         }
+    ),
+    new HTMLStylingMapDefinition(
+        'http://www.w3.org/ns/ttml#styling textDecoration',
+        function (context, dom_element, isd_element, attr) {
+            dom_element.style.textDecoration = attr.join(' ').replace('lineThrough', 'line-through');
+        }
+    ),
+    new HTMLStylingMapDefinition(
+        'http://www.w3.org/ns/ttml#styling textOutline',
+        function () { //function (context, dom_element, isd_element, attr) {
 
-    }
+            /* defer to tts:textShadow */
+        }
+    ),
+    new HTMLStylingMapDefinition(
+        'http://www.w3.org/ns/ttml#styling textShadow',
+        function (context, dom_element, isd_element, attr) {
 
-    function applyFillLineGap(lineList, par_before, par_after, context, element) {
+            var txto = isd_element.styleAttrs[imscStyles.byName.textOutline.qname];
 
-        /* positive for BPD = lr and tb, negative for BPD = rl */
-        var s = Math.sign(par_after - par_before);
+            if (attr === 'none' && txto === 'none') {
 
-        for (var i = 0; i <= lineList.length; i++) {
-
-            /* compute frontier between lines */
-
-            var frontier;
-
-            if (i === 0) {
-
-                frontier = Math.round(par_before);
-
-            } else if (i === lineList.length) {
-
-                frontier = Math.round(par_after);
+                dom_element.style.textShadow = '';
 
             } else {
 
-                frontier = Math.round((lineList[i - 1].after + lineList[i].before) / 2);
+                var s = [];
 
-            }
+                if (txto !== 'none') {
 
-            var padding;
-            var l,thisNode;
+                    /* emulate text outline */
 
-            /* before line */
-            if (i > 0) {
+                    var to_color = 'rgba(' +
+                        txto.color[0].toString() + ',' +
+                        txto.color[1].toString() + ',' +
+                        txto.color[2].toString() + ',' +
+                        (txto.color[3] / 255).toString() +
+                        ')';
 
-                if (lineList[i-1]) {
-
-                    for (l = 0; l < lineList[i - 1].elements.length; l++) {
-
-                        thisNode=lineList[i - 1].elements[l];
-                        padding = s*(frontier-thisNode.after) + "px";
-
-                        if (context.bpd === "lr") {
-
-                            thisNode.node.style.paddingRight = padding;
-
-                        } else if (context.bpd === "rl") {
-
-                            thisNode.node.style.paddingLeft = padding;
-
-                        } else if (context.bpd === "tb") {
-
-                            thisNode.node.style.paddingBottom = padding;
-
-                        }
-
-                    }
+                    s.push('1px 1px 1px ' + to_color);
+                    s.push('-1px 1px 1px ' + to_color);
+                    s.push('1px -1px 1px ' + to_color);
+                    s.push('-1px -1px 1px ' + to_color);
 
                 }
 
-            }
+                /* add text shadow */
 
-            /* after line */
-            if (i < lineList.length) {
-
-                for (l = 0; l < lineList[i].elements.length; l++) {
-
-                    thisNode = lineList[i].elements[l];
-                    padding = s * (thisNode.before - frontier) + "px";
-
-                    if (context.bpd === "lr") {
-
-                        thisNode.node.style.paddingLeft = padding;
-
-                    } else if (context.bpd === "rl") {
-
-                        thisNode.node.style.paddingRight = padding;
-
-                    } else if (context.bpd === "tb") {
-
-                        thisNode.node.style.paddingTop = padding;
-
-                    }
-                }
-
-            }
-
-        }
-
-    }
-
-    function RegionPBuffer(id, lineList) {
-
-        this.id = id;
-
-        this.plist = lineList;
-
-    }
-
-    function rect2edges(rect, context) {
-
-        var edges = {before: null, after: null, start: null, end: null};
-
-        if (context.bpd === "tb") {
-
-            edges.before = rect.top;
-            edges.after = rect.bottom;
-
-            if (context.ipd === "lr") {
-
-                edges.start = rect.left;
-                edges.end = rect.right;
-
-            } else {
-
-                edges.start = rect.right;
-                edges.end = rect.left;
-            }
-
-        } else if (context.bpd === "lr") {
-
-            edges.before = rect.left;
-            edges.after = rect.right;
-            edges.start = rect.top;
-            edges.end = rect.bottom;
-
-        } else if (context.bpd === "rl") {
-
-            edges.before = rect.right;
-            edges.after = rect.left;
-            edges.start = rect.top;
-            edges.end = rect.bottom;
-
-        }
-
-        return edges;
-
-    }
-
-    function constructLineList(context, element, llist, bgcolor) {
-
-        if (element.localName === "rt" || element.localName === "rtc") {
-
-            /* skip ruby annotations */
-
-            return;
-
-        }
-
-        var curbgcolor = element.style.backgroundColor || bgcolor;
-
-        if (element.childElementCount === 0) {
-
-            if (element.localName === 'span' || element.localName === 'rb') {
-
-                var r = element.getBoundingClientRect();
-
-                var edges = rect2edges(r, context);
-
-                if (llist.length === 0 ||
-                        (!isSameLine(edges.before, edges.after, llist[llist.length - 1].before, llist[llist.length - 1].after))
-                        ) {
-                    llist.push({
-                        before: edges.before,
-                        after: edges.after,
-                        start: edges.start,
-                        end: edges.end,
-                        start_elem: 0,
-                        end_elem: 0,
-                        elements: [],
-                        rbc: [],
-                        te: [],
-                        text: "",
-                        br: false
-                    });
-
-                } else {
-
-                    /* positive for BPD = lr and tb, negative for BPD = rl */
-                    var bpd_dir = Math.sign(edges.after - edges.before);
-
-                    /* positive for IPD = lr and tb, negative for IPD = rl */
-                    var ipd_dir = Math.sign(edges.end - edges.start);
-
-                    /* check if the line height has increased */
-
-                    if (bpd_dir * (edges.before - llist[llist.length - 1].before) < 0) {
-                        llist[llist.length - 1].before = edges.before;
-                    }
-
-                    if (bpd_dir * (edges.after - llist[llist.length - 1].after) > 0) {
-                        llist[llist.length - 1].after = edges.after;
-                    }
-
-                    if (ipd_dir * (edges.start - llist[llist.length - 1].start) < 0) {
-                        llist[llist.length - 1].start = edges.start;
-                        llist[llist.length - 1].start_elem = llist[llist.length - 1].elements.length;
-                    }
-
-                    if (ipd_dir * (edges.end - llist[llist.length - 1].end) > 0) {
-                        llist[llist.length - 1].end = edges.end;
-                        llist[llist.length - 1].end_elem = llist[llist.length - 1].elements.length;
-                    }
-
-                }
-
-                llist[llist.length - 1].text += element.textContent;
-
-                llist[llist.length - 1].elements.push(
-                        {
-                            node: element,
-                            bgcolor: curbgcolor,
-                            before: edges.before,
-                            after: edges.after
-                        }
-                );
-
-            } else if (element.localName === 'br' && llist.length !== 0) {
-
-                llist[llist.length - 1].br = true;
-
-            }
-
-        } else {
-
-            var child = element.firstChild;
-
-            while (child) {
-
-                if (child.nodeType === Node.ELEMENT_NODE) {
-
-                    constructLineList(context, child, llist, curbgcolor);
-
-                    if (child.localName === 'ruby' || child.localName === 'rtc') {
-
-                        /* remember non-empty ruby and rtc elements so that tts:rubyPosition can be applied */
-
-                        if (llist.length > 0) {
-
-                            llist[llist.length - 1].rbc.push(child);
-
-                        }
-
-                    } else if (child.localName === 'span' &&
-                            child.style[TEXTEMPHASISSTYLE_PROP] &&
-                            child.style[TEXTEMPHASISSTYLE_PROP] !== "none") {
-
-                        /* remember non-empty span elements with textEmphasis */
-
-                        if (llist.length > 0) {
-
-                            llist[llist.length - 1].te.push(child);
-
-                        }
-
-                    }
-                    
-
-                }
-
-                child = child.nextSibling;
-            }
-        }
-
-    }
-
-    function isSameLine(before1, after1, before2, after2) {
-
-        return ((after1 < after2) && (before1 > before2)) || ((after2 <= after1) && (before2 >= before1));
-
-    }
-
-    function applyTextEmphasis(context, dom_element, isd_element, attr) {
-
-        /* ignore color (not used in IMSC 1.1) */
-
-        if (attr.style === "none") {
-
-            /* text-emphasis is not inherited and the default is none, so nothing to do */
-            
-            return;
-        
-        } else if (attr.style === "auto") {
-
-            dom_element.style[TEXTEMPHASISSTYLE_PROP] = "filled";
-        
-        } else {
-
-            dom_element.style[TEXTEMPHASISSTYLE_PROP] =  attr.style + " " + attr.symbol;
-        }
-
-        /* ignore "outside" position (set in postprocessing) */
-
-        if (attr.position === "before" || attr.position === "after") {
-
-            var pos;
-
-            if (context.bpd === "tb") {
-
-                pos = (attr.position === "before") ? "left over" : "left under";
-
-
-            } else {
-
-                if (context.bpd === "rl") {
-
-                    pos = (attr.position === "before") ? "right under" : "left under";
-
-                } else {
-
-                    pos = (attr.position === "before") ? "left under" : "right under";
-
-                }
-
-            }
-
-            dom_element.style[TEXTEMPHASISPOSITION_PROP] = pos;
-        }
-    }
-
-    function HTMLStylingMapDefinition(qName, mapFunc) {
-        this.qname = qName;
-        this.map = mapFunc;
-    }
-
-    var STYLING_MAP_DEFS = [
-
-        new HTMLStylingMapDefinition(
-                "http://www.w3.org/ns/ttml#styling backgroundColor",
-                function (context, dom_element, isd_element, attr) {
-
-                    /* skip if transparent */
-                    if (attr[3] === 0)
-                        return;
-
-                    dom_element.style.backgroundColor = "rgba(" +
-                            attr[0].toString() + "," +
-                            attr[1].toString() + "," +
-                            attr[2].toString() + "," +
-                            (attr[3] / 255).toString() +
-                            ")";
-                }
-        ),
-        new HTMLStylingMapDefinition(
-                "http://www.w3.org/ns/ttml#styling color",
-                function (context, dom_element, isd_element, attr) {
-                    dom_element.style.color = "rgba(" +
-                            attr[0].toString() + "," +
-                            attr[1].toString() + "," +
-                            attr[2].toString() + "," +
-                            (attr[3] / 255).toString() +
-                            ")";
-                }
-        ),
-        new HTMLStylingMapDefinition(
-                "http://www.w3.org/ns/ttml#styling direction",
-                function (context, dom_element, isd_element, attr) {
-
-                    dom_element.style.direction = attr;
-
-                }
-        ),
-        new HTMLStylingMapDefinition(
-                "http://www.w3.org/ns/ttml#styling display",
-                function (context, dom_element, isd_element, attr) {}
-        ),
-        new HTMLStylingMapDefinition(
-                "http://www.w3.org/ns/ttml#styling displayAlign",
-                function (context, dom_element, isd_element, attr) {
-
-                    /* see https://css-tricks.com/snippets/css/a-guide-to-flexbox/ */
-
-                    /* TODO: is this affected by writing direction? */
-
-                    dom_element.style.display = "flex";
-                    dom_element.style.flexDirection = "column";
-
-
-                    if (attr === "before") {
-
-                        dom_element.style.justifyContent = "flex-start";
-
-                    } else if (attr === "center") {
-
-                        dom_element.style.justifyContent = "center";
-
-                    } else if (attr === "after") {
-
-                        dom_element.style.justifyContent = "flex-end";
-                    }
-
-                }
-        ),
-        new HTMLStylingMapDefinition(
-                "http://www.w3.org/ns/ttml#styling extent",
-                function (context, dom_element, isd_element, attr) {
-                    /* TODO: this is super ugly */
-
-                    context.regionH = attr.h.toUsedLength(context.w, context.h);
-                    context.regionW = attr.w.toUsedLength(context.w, context.h);
-
-                    /* 
-                     * CSS height/width are measured against the content rectangle,
-                     * whereas TTML height/width include padding
-                     */
-
-                    var hdelta = 0;
-                    var wdelta = 0;
-
-                    var p = isd_element.styleAttrs["http://www.w3.org/ns/ttml#styling padding"];
-
-                    if (!p) {
-
-                        /* error */
-
-                    } else {
-
-                        hdelta = p[0].toUsedLength(context.w, context.h) + p[2].toUsedLength(context.w, context.h);
-                        wdelta = p[1].toUsedLength(context.w, context.h) + p[3].toUsedLength(context.w, context.h);
-
-                    }
-
-                    dom_element.style.height = (context.regionH - hdelta) + "px";
-                    dom_element.style.width = (context.regionW - wdelta) + "px";
-
-                }
-        ),
-        new HTMLStylingMapDefinition(
-                "http://www.w3.org/ns/ttml#styling fontFamily",
-                function (context, dom_element, isd_element, attr) {
-
-                    var rslt = [];
-
-                    /* per IMSC1 */
+                if (attr !== 'none') {
 
                     for (var i = 0; i < attr.length; i++) {
 
-                        if (attr[i] === "monospaceSerif") {
 
-                            rslt.push("Courier New");
-                            rslt.push('"Liberation Mono"');
-                            rslt.push("Courier");
-                            rslt.push("monospace");
-
-                        } else if (attr[i] === "proportionalSansSerif") {
-
-                            rslt.push("Arial");
-                            rslt.push("Helvetica");
-                            rslt.push('"Liberation Sans"');
-                            rslt.push("sans-serif");
-
-                        } else if (attr[i] === "monospace") {
-
-                            rslt.push("monospace");
-
-                        } else if (attr[i] === "sansSerif") {
-
-                            rslt.push("sans-serif");
-
-                        } else if (attr[i] === "serif") {
-
-                            rslt.push("serif");
-
-                        } else if (attr[i] === "monospaceSansSerif") {
-
-                            rslt.push("Consolas");
-                            rslt.push("monospace");
-
-                        } else if (attr[i] === "proportionalSerif") {
-
-                            rslt.push("serif");
-
-                        } else {
-
-                            rslt.push(attr[i]);
-
-                        }
-
-                    }
-
-                    // prune later duplicates we may have inserted 
-                    if (rslt.length > 0) {
-
-                        var unique=[rslt[0]];
-
-                        for (var fi = 1; fi < rslt.length; fi++) {
-
-                            if (unique.indexOf(rslt[fi]) == -1) {
-
-                                unique.push(rslt[fi]);
-
-                            }
-                        }
-
-                        rslt = unique;
-                    }
-
-                    dom_element.style.fontFamily = rslt.join(",");
-                }
-        ),
-
-        new HTMLStylingMapDefinition(
-                "http://www.w3.org/ns/ttml#styling shear",
-                function (context, dom_element, isd_element, attr) {
-
-                    /* return immediately if tts:shear is 0% since CSS transforms are not inherited*/
-
-                    if (attr === 0)
-                        return;
-
-                    var angle = attr * -0.9;
-
-                    /* context.bpd is needed since writing mode is not inherited and sets the inline progression */
-
-                    if (context.bpd === "tb") {
-
-                        dom_element.style.transform = "skewX(" + angle + "deg)";
-
-                    } else {
-
-                        dom_element.style.transform = "skewY(" + angle + "deg)";
+                        s.push(attr[i].x_off.toUsedLength(context.w, context.h) + 'px ' +
+                            attr[i].y_off.toUsedLength(context.w, context.h) + 'px ' +
+                            attr[i].b_radius.toUsedLength(context.w, context.h) + 'px ' +
+                            'rgba(' +
+                            attr[i].color[0].toString() + ',' +
+                            attr[i].color[1].toString() + ',' +
+                            attr[i].color[2].toString() + ',' +
+                            (attr[i].color[3] / 255).toString() +
+                            ')'
+                        );
 
                     }
 
                 }
-        ),
 
-        new HTMLStylingMapDefinition(
-                "http://www.w3.org/ns/ttml#styling fontSize",
-                function (context, dom_element, isd_element, attr) {
-                    dom_element.style.fontSize = attr.toUsedLength(context.w, context.h) + "px";
+                dom_element.style.textShadow = s.join(',');
+
+            }
+        }
+    ),
+    new HTMLStylingMapDefinition(
+        'http://www.w3.org/ns/ttml#styling textCombine',
+        function (context, dom_element, isd_element, attr) {
+
+            dom_element.style.textCombineUpright = attr;
+
+        }
+    ),
+    new HTMLStylingMapDefinition(
+        'http://www.w3.org/ns/ttml#styling textEmphasis',
+        function () { // function (context, dom_element, isd_element, attr) {
+
+            /* applied as part of HTML document construction */
+
+        }
+    ),
+    new HTMLStylingMapDefinition(
+        'http://www.w3.org/ns/ttml#styling unicodeBidi',
+        function (context, dom_element, isd_element, attr) {
+
+            var ub;
+
+            if (attr === 'bidiOverride') {
+                ub = 'bidi-override';
+            } else {
+                ub = attr;
+            }
+
+            dom_element.style.unicodeBidi = ub;
+        }
+    ),
+    new HTMLStylingMapDefinition(
+        'http://www.w3.org/ns/ttml#styling visibility',
+        function (context, dom_element, isd_element, attr) {
+            dom_element.style.visibility = attr;
+        }
+    ),
+    new HTMLStylingMapDefinition(
+        'http://www.w3.org/ns/ttml#styling wrapOption',
+        function (context, dom_element, isd_element, attr) {
+
+            if (attr === 'wrap') {
+
+                if (isd_element.space === 'preserve') {
+                    dom_element.style.whiteSpace = 'pre-wrap';
+                } else {
+                    dom_element.style.whiteSpace = 'normal';
                 }
-        ),
 
-        new HTMLStylingMapDefinition(
-                "http://www.w3.org/ns/ttml#styling fontStyle",
-                function (context, dom_element, isd_element, attr) {
-                    dom_element.style.fontStyle = attr;
+            } else {
+
+                if (isd_element.space === 'preserve') {
+
+                    dom_element.style.whiteSpace = 'pre';
+
+                } else {
+                    dom_element.style.whiteSpace = 'noWrap';
                 }
-        ),
-        new HTMLStylingMapDefinition(
-                "http://www.w3.org/ns/ttml#styling fontWeight",
-                function (context, dom_element, isd_element, attr) {
-                    dom_element.style.fontWeight = attr;
-                }
-        ),
-        new HTMLStylingMapDefinition(
-                "http://www.w3.org/ns/ttml#styling lineHeight",
-                function (context, dom_element, isd_element, attr) {
-                    if (attr === "normal") {
-
-                        dom_element.style.lineHeight = "normal";
-
-                    } else {
-
-                        dom_element.style.lineHeight = attr.toUsedLength(context.w, context.h) + "px";
-                    }
-                }
-        ),
-        new HTMLStylingMapDefinition(
-                "http://www.w3.org/ns/ttml#styling opacity",
-                function (context, dom_element, isd_element, attr) {
-                    dom_element.style.opacity = attr;
-                }
-        ),
-        new HTMLStylingMapDefinition(
-                "http://www.w3.org/ns/ttml#styling origin",
-                function (context, dom_element, isd_element, attr) {
-                    dom_element.style.top = attr.h.toUsedLength(context.w, context.h) + "px";
-                    dom_element.style.left = attr.w.toUsedLength(context.w, context.h) + "px";
-                }
-        ),
-        new HTMLStylingMapDefinition(
-                "http://www.w3.org/ns/ttml#styling overflow",
-                function (context, dom_element, isd_element, attr) {
-                    dom_element.style.overflow = attr;
-                }
-        ),
-        new HTMLStylingMapDefinition(
-                "http://www.w3.org/ns/ttml#styling padding",
-                function (context, dom_element, isd_element, attr) {
-
-                    /* attr: top,left,bottom,right*/
-
-                    /* style: top right bottom left*/
-
-                    var rslt = [];
-
-                    rslt[0] = attr[0].toUsedLength(context.w, context.h) + "px";
-                    rslt[1] = attr[3].toUsedLength(context.w, context.h) + "px";
-                    rslt[2] = attr[2].toUsedLength(context.w, context.h) + "px";
-                    rslt[3] = attr[1].toUsedLength(context.w, context.h) + "px";
-
-                    dom_element.style.padding = rslt.join(" ");
-                }
-        ),
-        new HTMLStylingMapDefinition(
-                "http://www.w3.org/ns/ttml#styling position",
-                function (context, dom_element, isd_element, attr) {
-                    dom_element.style.top = attr.h.toUsedLength(context.w, context.h) + "px";
-                    dom_element.style.left = attr.w.toUsedLength(context.w, context.h) + "px";
-                }
-        ),
-        new HTMLStylingMapDefinition(
-                "http://www.w3.org/ns/ttml#styling rubyAlign",
-                function (context, dom_element, isd_element, attr) {
-                    dom_element.style.rubyAlign = attr === "spaceAround" ? "space-around" : "center";
-                }
-        ),
-        new HTMLStylingMapDefinition(
-                "http://www.w3.org/ns/ttml#styling rubyPosition",
-                function (context, dom_element, isd_element, attr) {
 
-                    /* skip if "outside", which is handled by applyRubyPosition() */
+            }
 
-                    if (attr === "before" || attr === "after") {
-
-                        var pos;
+        }
+    ),
+    new HTMLStylingMapDefinition(
+        'http://www.w3.org/ns/ttml#styling writingMode',
+        function (context, dom_element, isd_element, attr) {
 
-                        if (RUBYPOSITION_ISWK) {
-
-                            /* WebKit exception */
-        
-                            pos = attr;
-        
-                        } else if (context.bpd === "tb") {
+            if (attr === 'lrtb' || attr === 'lr') {
 
-                            pos = (attr === "before") ? "over" : "under";
+                dom_element.style.writingMode = 'horizontal-tb';
 
+            } else if (attr === 'rltb' || attr === 'rl') {
 
-                        } else {
+                dom_element.style.writingMode = 'horizontal-tb';
 
-                            if (context.bpd === "rl") {
+            } else if (attr === 'tblr') {
 
-                                pos = (attr === "before") ? "over" : "under";
+                dom_element.style.writingMode = 'vertical-lr';
 
-                            } else {
+            } else if (attr === 'tbrl' || attr === 'tb') {
 
-                                pos = (attr === "before") ? "under" : "over";
+                dom_element.style.writingMode = 'vertical-rl';
 
-                            }
+            }
 
-                        }
+        }
+    ),
+    new HTMLStylingMapDefinition(
+        'http://www.w3.org/ns/ttml#styling zIndex',
+        function (context, dom_element, isd_element, attr) {
+            dom_element.style.zIndex = attr;
+        }
+    ),
+    new HTMLStylingMapDefinition(
+        'http://www.w3.org/ns/ttml/profile/imsc1#styling forcedDisplay',
+        function (context, dom_element, isd_element, attr) {
 
-                        /* apply position to the parent dom_element, i.e. ruby or rtc */
+            if (context.displayForcedOnlyMode && attr === false) {
+                dom_element.style.visibility = 'hidden';
+            }
 
-                        dom_element.parentElement.style[RUBYPOSITION_PROP] = pos;
-                    }
-                }
-        ),
-        new HTMLStylingMapDefinition(
-                "http://www.w3.org/ns/ttml#styling showBackground",
-                null
-                ),
-        new HTMLStylingMapDefinition(
-                "http://www.w3.org/ns/ttml#styling textAlign",
-                function (context, dom_element, isd_element, attr) {
+        }
+    )
+];
 
-                    var ta;
+var STYLMAP_BY_QNAME = {};
 
-                    /* handle UAs that do not understand start or end */
+for (var i = 0; i < STYLING_MAP_DEFS.length; i++) {
 
-                    if (attr === "start") {
+    STYLMAP_BY_QNAME[STYLING_MAP_DEFS[i].qname] = STYLING_MAP_DEFS[i];
+}
 
-                        ta = (context.ipd === "rl") ? "right" : "left";
+/* CSS property names */
 
-                    } else if (attr === "end") {
+var RUBYPOSITION_ISWK = 'webkitRubyPosition' in window.getComputedStyle(document.documentElement);
 
-                        ta = (context.ipd === "rl") ? "left" : "right";
+var RUBYPOSITION_PROP = RUBYPOSITION_ISWK ? 'webkitRubyPosition' : 'rubyPosition';
 
-                    } else {
+var TEXTEMPHASISSTYLE_PROP = 'webkitTextEmphasisStyle' in window.getComputedStyle(document.documentElement) ? 'webkitTextEmphasisStyle' : 'textEmphasisStyle';
 
-                        ta = attr;
+var TEXTEMPHASISPOSITION_PROP = 'webkitTextEmphasisPosition' in window.getComputedStyle(document.documentElement) ? 'webkitTextEmphasisPosition' : 'textEmphasisPosition';
 
-                    }
-
-                    dom_element.style.textAlign = ta;
-
-                }
-        ),
-        new HTMLStylingMapDefinition(
-                "http://www.w3.org/ns/ttml#styling textDecoration",
-                function (context, dom_element, isd_element, attr) {
-                    dom_element.style.textDecoration = attr.join(" ").replace("lineThrough", "line-through");
-                }
-        ),
-        new HTMLStylingMapDefinition(
-                "http://www.w3.org/ns/ttml#styling textOutline",
-                function (context, dom_element, isd_element, attr) {
-
-                    /* defer to tts:textShadow */
-                }
-        ),
-        new HTMLStylingMapDefinition(
-                "http://www.w3.org/ns/ttml#styling textShadow",
-                function (context, dom_element, isd_element, attr) {
-
-                    var txto = isd_element.styleAttrs[imscStyles.byName.textOutline.qname];
-
-                    if (attr === "none" && txto === "none") {
-
-                        dom_element.style.textShadow = "";
-
-                    } else {
-
-                        var s = [];
-
-                        if (txto !== "none") {
-
-                            /* emulate text outline */
-
-                            var to_color = "rgba(" +
-                                                txto.color[0].toString() + "," +
-                                                txto.color[1].toString() + "," +
-                                                txto.color[2].toString() + "," +
-                                                (txto.color[3] / 255).toString() +
-                                                ")";
-
-                            s.push(  "1px 1px 1px " + to_color);
-                            s.push(  "-1px 1px 1px " + to_color);
-                            s.push(  "1px -1px 1px " + to_color);
-                            s.push(  "-1px -1px 1px " + to_color);
-
-                        }
-
-                        /* add text shadow */
-
-                        if (attr !== "none") {
-
-                            for (var i = 0; i < attr.length; i++) {
-
-
-                                s.push(attr[i].x_off.toUsedLength(context.w, context.h) + "px " +
-                                        attr[i].y_off.toUsedLength(context.w, context.h) + "px " +
-                                        attr[i].b_radius.toUsedLength(context.w, context.h) + "px " +
-                                        "rgba(" +
-                                        attr[i].color[0].toString() + "," +
-                                        attr[i].color[1].toString() + "," +
-                                        attr[i].color[2].toString() + "," +
-                                        (attr[i].color[3] / 255).toString() +
-                                        ")"
-                                        );
-
-                            }
-
-                        }
-
-                        dom_element.style.textShadow = s.join(",");
-
-                    }
-                }
-        ),
-        new HTMLStylingMapDefinition(
-                "http://www.w3.org/ns/ttml#styling textCombine",
-                function (context, dom_element, isd_element, attr) {
-
-                    dom_element.style.textCombineUpright = attr;
-
-                }
-        ),
-        new HTMLStylingMapDefinition(
-                "http://www.w3.org/ns/ttml#styling textEmphasis",
-                function (context, dom_element, isd_element, attr) {
-
-                    /* applied as part of HTML document construction */
-
-                }
-        ),
-        new HTMLStylingMapDefinition(
-                "http://www.w3.org/ns/ttml#styling unicodeBidi",
-                function (context, dom_element, isd_element, attr) {
-
-                    var ub;
-
-                    if (attr === 'bidiOverride') {
-                        ub = "bidi-override";
-                    } else {
-                        ub = attr;
-                    }
-
-                    dom_element.style.unicodeBidi = ub;
-                }
-        ),
-        new HTMLStylingMapDefinition(
-                "http://www.w3.org/ns/ttml#styling visibility",
-                function (context, dom_element, isd_element, attr) {
-                    dom_element.style.visibility = attr;
-                }
-        ),
-        new HTMLStylingMapDefinition(
-                "http://www.w3.org/ns/ttml#styling wrapOption",
-                function (context, dom_element, isd_element, attr) {
-
-                    if (attr === "wrap") {
-
-                        if (isd_element.space === "preserve") {
-                            dom_element.style.whiteSpace = "pre-wrap";
-                        } else {
-                            dom_element.style.whiteSpace = "normal";
-                        }
-
-                    } else {
-
-                        if (isd_element.space === "preserve") {
-
-                            dom_element.style.whiteSpace = "pre";
-
-                        } else {
-                            dom_element.style.whiteSpace = "noWrap";
-                        }
-
-                    }
-
-                }
-        ),
-        new HTMLStylingMapDefinition(
-                "http://www.w3.org/ns/ttml#styling writingMode",
-                function (context, dom_element, isd_element, attr) {
-
-                    var wm;
-
-                    if (attr === "lrtb" || attr === "lr") {
-
-                        dom_element.style.writingMode = "horizontal-tb";
-
-                    } else if (attr === "rltb" || attr === "rl") {
-
-                        dom_element.style.writingMode = "horizontal-tb";
-
-                    } else if (attr === "tblr") {
-
-                        dom_element.style.writingMode = "vertical-lr";
-
-                    } else if (attr === "tbrl" || attr === "tb") {
-
-                        dom_element.style.writingMode = "vertical-rl";
-
-                    }
-
-                }
-        ),
-        new HTMLStylingMapDefinition(
-                "http://www.w3.org/ns/ttml#styling zIndex",
-                function (context, dom_element, isd_element, attr) {
-                    dom_element.style.zIndex = attr;
-                }
-        ),
-        new HTMLStylingMapDefinition(
-                "http://www.w3.org/ns/ttml/profile/imsc1#styling forcedDisplay",
-                function (context, dom_element, isd_element, attr) {
-
-                    if (context.displayForcedOnlyMode && attr === false) {
-                        dom_element.style.visibility = "hidden";
-                    }
-
-                }
-        )
-    ];
-
-    var STYLMAP_BY_QNAME = {};
-
-    for (var i = 0; i < STYLING_MAP_DEFS.length; i++) {
-
-        STYLMAP_BY_QNAME[STYLING_MAP_DEFS[i].qname] = STYLING_MAP_DEFS[i];
-    }
-
-    /* CSS property names */
-
-    var RUBYPOSITION_ISWK = "webkitRubyPosition" in window.getComputedStyle(document.documentElement);
-
-    var RUBYPOSITION_PROP = RUBYPOSITION_ISWK ? "webkitRubyPosition" : "rubyPosition";
-
-    var TEXTEMPHASISSTYLE_PROP = "webkitTextEmphasisStyle" in window.getComputedStyle(document.documentElement) ? "webkitTextEmphasisStyle" : "textEmphasisStyle";
-
-    var TEXTEMPHASISPOSITION_PROP = "webkitTextEmphasisPosition" in window.getComputedStyle(document.documentElement) ? "webkitTextEmphasisPosition" : "textEmphasisPosition";
-
-    /* error utilities */
-
-    function reportError(errorHandler, msg) {
-
-        if (errorHandler && errorHandler.error && errorHandler.error(msg))
-            throw msg;
-
-    }
-
-})(typeof exports === 'undefined' ? this.imscHTML = {} : exports,
-        typeof imscNames === 'undefined' ? require("./names") : imscNames,
-        typeof imscStyles === 'undefined' ? require("./styles") : imscStyles,
-        typeof imscUtils === 'undefined' ? require("./utils") : imscUtils);
+module.exports = imscHTML;

--- a/src/main/js/isd.js
+++ b/src/main/js/isd.js
@@ -28,802 +28,796 @@
  * @module imscISD
  */
 
+const imscISD = {};
+const imscStyles = require('./styles');
+const imscUtils = require('./utils');
 
-;
-(function (imscISD, imscNames, imscStyles, imscUtils) { // wrapper for non-node envs
+/**
+ * Creates a canonical representation of an IMSC1 document returned by <pre>imscDoc.fromXML()</pre>
+ * at a given absolute offset in seconds. This offset does not have to be one of the values returned
+ * by <pre>getMediaTimeEvents()</pre>.
+ *
+ * @param {Object} tt IMSC1 document
+ * @param {number} offset Absolute offset (in seconds)
+ * @param {?module:imscUtils.ErrorHandler} errorHandler Error callback
+ * @returns {Object} Opaque in-memory representation of an ISD
+ */
 
-    /** 
-     * Creates a canonical representation of an IMSC1 document returned by <pre>imscDoc.fromXML()</pre>
-     * at a given absolute offset in seconds. This offset does not have to be one of the values returned
-     * by <pre>getMediaTimeEvents()</pre>.
-     * 
-     * @param {Object} tt IMSC1 document
-     * @param {number} offset Absolute offset (in seconds)
-     * @param {?module:imscUtils.ErrorHandler} errorHandler Error callback
-     * @returns {Object} Opaque in-memory representation of an ISD
-     */
+imscISD.generateISD = function (tt, offset, errorHandler) {
 
-    imscISD.generateISD = function (tt, offset, errorHandler) {
+    /* TODO check for tt and offset validity */
 
-        /* TODO check for tt and offset validity */
+    /* create the ISD object from the IMSC1 doc */
 
-        /* create the ISD object from the IMSC1 doc */
+    var isd = new ISD(tt);
 
-        var isd = new ISD(tt);
+    /* context */
 
-        /* context */
+    var context = {
 
-        var context = {
+        /*rubyfs: []*/ /* font size of the nearest textContainer or container */
 
-            /*rubyfs: []*/ /* font size of the nearest textContainer or container */
-
-        };
-
-        /* Filter body contents - Only process what we need within the offset and discard regions not applicable to the content */
-        var body = {};
-        var activeRegions = {};
-
-        /* gather any regions that might have showBackground="always" and show a background */
-        var initialShowBackground = tt.head.styling.initials[imscStyles.byName.showBackground.qname];
-        var initialbackgroundColor = tt.head.styling.initials[imscStyles.byName.backgroundColor.qname];
-        for (var layout_child in tt.head.layout.regions)
-        {
-            if (tt.head.layout.regions.hasOwnProperty(layout_child)) {
-                var region = tt.head.layout.regions[layout_child];
-                var showBackground = region.styleAttrs[imscStyles.byName.showBackground.qname] || initialShowBackground;
-                var backgroundColor = region.styleAttrs[imscStyles.byName.backgroundColor.qname] || initialbackgroundColor;
-                activeRegions[region.id] = (
-                    (showBackground === 'always' || showBackground === undefined) &&
-                    backgroundColor !== undefined &&
-                    !(offset < region.begin || offset >= region.end)
-                    );
-            }
-        }
-
-        /* If the body specifies a region, catch it, since no filtered content will */
-        /* likely specify the region. */
-        if (tt.body && tt.body.regionID) {
-            activeRegions[tt.body.regionID] = true;
-        }
-
-        function filter(offset, element) {
-            function offsetFilter(element) {
-                return !(offset < element.begin || offset >= element.end);    
-            }    
-        
-            if (element.contents) {
-                var clone = {};
-                for (var prop in element) {
-                    if (element.hasOwnProperty(prop)) {
-                        clone[prop] = element[prop];
-                    }
-                }
-                clone.contents = [];
-
-                element.contents.filter(offsetFilter).forEach(function (el) {
-                    var filteredElement = filter(offset, el);
-                    if (filteredElement.regionID) {
-                        activeRegions[filteredElement.regionID] = true;
-                    }
-        
-                    if (filteredElement !== null) {
-                        clone.contents.push(filteredElement);
-                    }
-                });
-                return clone;
-            } else {
-                return element;
-            }
-        }
-
-        if (tt.body !== null) {
-            body = filter(offset, tt.body);
-        } else {
-            body = null;
-        }
-
-        /* rewritten TTML will always have a default - this covers it. because the region is defaulted to "" */
-        if (activeRegions[""] !== undefined) {
-            activeRegions[""] = true;
-        }
-
-        /* process regions */      
-        for (var regionID in activeRegions) {
-            if (activeRegions[regionID]) {
-                /* post-order traversal of the body tree per [construct intermediate document] */
-
-                var c = isdProcessContentElement(tt, offset, tt.head.layout.regions[regionID], body, null, '', tt.head.layout.regions[regionID], errorHandler, context);
-
-                if (c !== null) {
-
-                    /* add the region to the ISD */
-
-                    isd.contents.push(c.element);
-                }
-            }
-        }
-
-        return isd;
     };
 
-    /* set of styles not applicable to ruby container spans */
+    /* Filter body contents - Only process what we need within the offset and discard regions not applicable to the content */
+    var body = {};
+    var activeRegions = {};
 
-    var _rcs_na_styles = [
-        imscStyles.byName.color.qname,
-        imscStyles.byName.textCombine.qname,
-        imscStyles.byName.textDecoration.qname,
-        imscStyles.byName.textEmphasis.qname,
-        imscStyles.byName.textOutline.qname,
-        imscStyles.byName.textShadow.qname
-    ];
+    /* gather any regions that might have showBackground="always" and show a background */
+    var initialShowBackground = tt.head.styling.initials[imscStyles.byName.showBackground.qname];
+    var initialbackgroundColor = tt.head.styling.initials[imscStyles.byName.backgroundColor.qname];
+    for (var layout_child in tt.head.layout.regions) {
+        if (imscUtils.checkHasOwnProperty(tt.head.layout.regions, layout_child)) {
+            var region = tt.head.layout.regions[layout_child];
+            var showBackground = region.styleAttrs[imscStyles.byName.showBackground.qname] || initialShowBackground;
+            var backgroundColor = region.styleAttrs[imscStyles.byName.backgroundColor.qname] || initialbackgroundColor;
+            activeRegions[region.id] = (
+                (showBackground === 'always' || showBackground === undefined) &&
+                backgroundColor !== undefined &&
+                !(offset < region.begin || offset >= region.end)
+            );
+        }
+    }
 
-    function isdProcessContentElement(doc, offset, region, body, parent, inherited_region_id, elem, errorHandler, context) {
+    /* If the body specifies a region, catch it, since no filtered content will */
+    /* likely specify the region. */
+    if (tt.body && tt.body.regionID) {
+        activeRegions[tt.body.regionID] = true;
+    }
 
-        /* prune if temporally inactive */
-
-        if (offset < elem.begin || offset >= elem.end) {
-            return null;
+    function filter(offset, element) {
+        function offsetFilter(element) {
+            return !(offset < element.begin || offset >= element.end);
         }
 
-        /* 
-         * set the associated region as specified by the regionID attribute, or the 
-         * inherited associated region otherwise
-         */
-
-        var associated_region_id = 'regionID' in elem && elem.regionID !== '' ? elem.regionID : inherited_region_id;
-
-        /* prune the element if either:
-         * - the element is not terminal and the associated region is neither the default
-         *   region nor the parent region (this allows children to be associated with a 
-         *   region later on)
-         * - the element is terminal and the associated region is not the parent region
-         */
-
-        /* TODO: improve detection of terminal elements since <region> has no contents */
-
-        if (parent !== null /* are we in the region element */ &&
-            associated_region_id !== region.id &&
-            (
-                (!('contents' in elem)) ||
-                ('contents' in elem && elem.contents.length === 0) ||
-                associated_region_id !== ''
-                )
-            )
-            return null;
-
-        /* create an ISD element, including applying specified styles */
-
-        var isd_element = new ISDContentElement(elem);
-
-        /* apply set (animation) styling */
-
-        if ("sets" in elem) {
-            for (var i = 0; i < elem.sets.length; i++) {
-
-                if (offset < elem.sets[i].begin || offset >= elem.sets[i].end)
-                    continue;
-
-                isd_element.styleAttrs[elem.sets[i].qname] = elem.sets[i].value;
-
+        if (element.contents) {
+            var clone = {};
+            for (var prop in element) {
+                if (imscUtils.checkHasOwnProperty(element, prop)) {
+                    clone[prop] = element[prop];
+                }
             }
-        }
+            clone.contents = [];
 
-        /* 
-         * keep track of specified styling attributes so that we
-         * can compute them later
-         */
-
-        var spec_attr = {};
-
-        for (var qname in isd_element.styleAttrs) {
-
-            if (! isd_element.styleAttrs.hasOwnProperty(qname)) continue;
-
-            spec_attr[qname] = true;
-
-            /* special rule for tts:writingMode (section 7.29.1 of XSL)
-             * direction is set consistently with writingMode only
-             * if writingMode sets inline-direction to LTR or RTL  
-             */
-
-            if (isd_element.kind === 'region' &&
-                qname === imscStyles.byName.writingMode.qname &&
-                !(imscStyles.byName.direction.qname in isd_element.styleAttrs)) {
-
-                var wm = isd_element.styleAttrs[qname];
-
-                if (wm === "lrtb" || wm === "lr") {
-
-                    isd_element.styleAttrs[imscStyles.byName.direction.qname] = "ltr";
-
-                } else if (wm === "rltb" || wm === "rl") {
-
-                    isd_element.styleAttrs[imscStyles.byName.direction.qname] = "rtl";
-
+            element.contents.filter(offsetFilter).forEach(function (el) {
+                var filteredElement = filter(offset, el);
+                if (filteredElement.regionID) {
+                    activeRegions[filteredElement.regionID] = true;
                 }
 
+                if (filteredElement !== null) {
+                    clone.contents.push(filteredElement);
+                }
+            });
+            return clone;
+        } else {
+            return element;
+        }
+    }
+
+    if (tt.body !== null) {
+        body = filter(offset, tt.body);
+    } else {
+        body = null;
+    }
+
+    /* rewritten TTML will always have a default - this covers it. because the region is defaulted to "" */
+    if (activeRegions[''] !== undefined) {
+        activeRegions[''] = true;
+    }
+
+    /* process regions */
+    for (var regionID in activeRegions) {
+        if (activeRegions[regionID]) {
+            /* post-order traversal of the body tree per [construct intermediate document] */
+
+            var c = isdProcessContentElement(tt, offset, tt.head.layout.regions[regionID], body, null, '', tt.head.layout.regions[regionID], errorHandler, context);
+
+            if (c !== null) {
+
+                /* add the region to the ISD */
+
+                isd.contents.push(c.element);
             }
         }
+    }
 
-        /* inherited styling */
+    return isd;
+};
 
-        if (parent !== null) {
+/* set of styles not applicable to ruby container spans */
 
-            for (var j = 0; j < imscStyles.all.length; j++) {
+var _rcs_na_styles = [
+    imscStyles.byName.color.qname,
+    imscStyles.byName.textCombine.qname,
+    imscStyles.byName.textDecoration.qname,
+    imscStyles.byName.textEmphasis.qname,
+    imscStyles.byName.textOutline.qname,
+    imscStyles.byName.textShadow.qname
+];
 
-                var sa = imscStyles.all[j];
+function isdProcessContentElement(doc, offset, region, body, parent, inherited_region_id, elem, errorHandler, context) {
 
-                /* textDecoration has special inheritance rules */
+    /* prune if temporally inactive */
 
-                if (sa.qname === imscStyles.byName.textDecoration.qname) {
+    if (offset < elem.begin || offset >= elem.end) {
+        return null;
+    }
 
-                    /* handle both textDecoration inheritance and specification */
+    /*
+     * set the associated region as specified by the regionID attribute, or the
+     * inherited associated region otherwise
+     */
 
-                    var ps = parent.styleAttrs[sa.qname];
-                    var es = isd_element.styleAttrs[sa.qname];
-                    var outs = [];
+    var associated_region_id = 'regionID' in elem && elem.regionID !== '' ? elem.regionID : inherited_region_id;
 
-                    if (es === undefined) {
+    /* prune the element if either:
+     * - the element is not terminal and the associated region is neither the default
+     *   region nor the parent region (this allows children to be associated with a
+     *   region later on)
+     * - the element is terminal and the associated region is not the parent region
+     */
 
-                        outs = ps;
+    /* TODO: improve detection of terminal elements since <region> has no contents */
 
-                    } else if (es.indexOf("none") === -1) {
+    if (parent !== null /* are we in the region element */ &&
+        associated_region_id !== region.id &&
+        (
+            (!('contents' in elem)) ||
+            ('contents' in elem && elem.contents.length === 0) ||
+            associated_region_id !== ''
+        )
+    )
+        return null;
 
-                        if ((es.indexOf("noUnderline") === -1 &&
-                            ps.indexOf("underline") !== -1) ||
-                            es.indexOf("underline") !== -1) {
+    /* create an ISD element, including applying specified styles */
 
-                            outs.push("underline");
+    var isd_element = new ISDContentElement(elem);
 
-                        }
+    /* apply set (animation) styling */
 
-                        if ((es.indexOf("noLineThrough") === -1 &&
-                            ps.indexOf("lineThrough") !== -1) ||
-                            es.indexOf("lineThrough") !== -1) {
+    if ('sets' in elem) {
+        for (var i = 0; i < elem.sets.length; i++) {
 
-                            outs.push("lineThrough");
+            if (offset < elem.sets[i].begin || offset >= elem.sets[i].end)
+                continue;
 
-                        }
+            isd_element.styleAttrs[elem.sets[i].qname] = elem.sets[i].value;
 
-                        if ((es.indexOf("noOverline") === -1 &&
-                            ps.indexOf("overline") !== -1) ||
-                            es.indexOf("overline") !== -1) {
+        }
+    }
 
-                            outs.push("overline");
+    /*
+     * keep track of specified styling attributes so that we
+     * can compute them later
+     */
 
-                        }
+    var spec_attr = {};
 
-                    } else {
+    for (var qname in isd_element.styleAttrs) {
 
-                        outs.push("none");
+        if (!imscUtils.checkHasOwnProperty(isd_element.styleAttrs, qname)) continue;
+
+        spec_attr[qname] = true;
+
+        /* special rule for tts:writingMode (section 7.29.1 of XSL)
+         * direction is set consistently with writingMode only
+         * if writingMode sets inline-direction to LTR or RTL
+         */
+
+        if (isd_element.kind === 'region' &&
+            qname === imscStyles.byName.writingMode.qname &&
+            !(imscStyles.byName.direction.qname in isd_element.styleAttrs)) {
+
+            var wm = isd_element.styleAttrs[qname];
+
+            if (wm === 'lrtb' || wm === 'lr') {
+
+                isd_element.styleAttrs[imscStyles.byName.direction.qname] = 'ltr';
+
+            } else if (wm === 'rltb' || wm === 'rl') {
+
+                isd_element.styleAttrs[imscStyles.byName.direction.qname] = 'rtl';
+
+            }
+
+        }
+    }
+
+    /* inherited styling */
+
+    if (parent !== null) {
+
+        for (var j = 0; j < imscStyles.all.length; j++) {
+
+            var sa = imscStyles.all[j];
+
+            /* textDecoration has special inheritance rules */
+
+            if (sa.qname === imscStyles.byName.textDecoration.qname) {
+
+                /* handle both textDecoration inheritance and specification */
+
+                var ps = parent.styleAttrs[sa.qname];
+                var es = isd_element.styleAttrs[sa.qname];
+                var outs = [];
+
+                if (es === undefined) {
+
+                    outs = ps;
+
+                } else if (es.indexOf('none') === -1) {
+
+                    if ((es.indexOf('noUnderline') === -1 &&
+                            ps.indexOf('underline') !== -1) ||
+                        es.indexOf('underline') !== -1) {
+
+                        outs.push('underline');
 
                     }
 
-                    isd_element.styleAttrs[sa.qname] = outs;
+                    if ((es.indexOf('noLineThrough') === -1 &&
+                            ps.indexOf('lineThrough') !== -1) ||
+                        es.indexOf('lineThrough') !== -1) {
 
-                } else if (sa.qname === imscStyles.byName.fontSize.qname &&
-                    !(sa.qname in isd_element.styleAttrs) &&
-                    isd_element.kind === 'span' &&
-                    isd_element.styleAttrs[imscStyles.byName.ruby.qname] === "textContainer") {
-                    
-                    /* special inheritance rule for ruby text container font size */
-                    
-                    var ruby_fs = parent.styleAttrs[imscStyles.byName.fontSize.qname];
+                        outs.push('lineThrough');
 
-                    isd_element.styleAttrs[sa.qname] = new imscUtils.ComputedLength(
-                        0.5 * ruby_fs.rw,
-                        0.5 * ruby_fs.rh);
-
-                } else if (sa.qname === imscStyles.byName.fontSize.qname &&
-                    !(sa.qname in isd_element.styleAttrs) &&
-                    isd_element.kind === 'span' &&
-                    isd_element.styleAttrs[imscStyles.byName.ruby.qname] === "text") {
-                    
-                    /* special inheritance rule for ruby text font size */
-                    
-                    var parent_fs = parent.styleAttrs[imscStyles.byName.fontSize.qname];
-                    
-                    if (parent.styleAttrs[imscStyles.byName.ruby.qname] === "textContainer") {
-                        
-                        isd_element.styleAttrs[sa.qname] = parent_fs;
-                        
-                    } else {
-                        
-                        isd_element.styleAttrs[sa.qname] = new imscUtils.ComputedLength(
-                            0.5 * parent_fs.rw,
-                            0.5 * parent_fs.rh);
                     }
-                    
-                } else if (sa.inherit &&
-                    (sa.qname in parent.styleAttrs) &&
-                    !(sa.qname in isd_element.styleAttrs)) {
 
-                    isd_element.styleAttrs[sa.qname] = parent.styleAttrs[sa.qname];
+                    if ((es.indexOf('noOverline') === -1 &&
+                            ps.indexOf('overline') !== -1) ||
+                        es.indexOf('overline') !== -1) {
 
-                }
+                        outs.push('overline');
 
-            }
-
-        }
-
-        /* initial value styling */
-
-        for (var k = 0; k < imscStyles.all.length; k++) {
-            
-            var ivs = imscStyles.all[k];
-
-            /* skip if value is already specified */
-
-            if (ivs.qname in isd_element.styleAttrs) continue;
-
-            /* skip tts:position if tts:origin is specified */
-
-            if (ivs.qname === imscStyles.byName.position.qname &&
-                imscStyles.byName.origin.qname in isd_element.styleAttrs)
-                continue;
-
-            /* skip tts:origin if tts:position is specified */
-
-            if (ivs.qname === imscStyles.byName.origin.qname &&
-                imscStyles.byName.position.qname in isd_element.styleAttrs)
-                continue;
-            
-            /* determine initial value */
-            
-            var iv = doc.head.styling.initials[ivs.qname] || ivs.initial;
-
-            if (iv === null) {
-                /* skip processing if no initial value defined */
-
-                continue;
-            }
-
-            /* apply initial value to elements other than region only if non-inherited */
-
-            if (isd_element.kind === 'region' || (ivs.inherit === false && iv !== null)) {
-
-                var piv = ivs.parse(iv);
-
-                if (piv !== null) {
-
-                    isd_element.styleAttrs[ivs.qname] = piv;
-
-                    /* keep track of the style as specified */
-
-                    spec_attr[ivs.qname] = true;
+                    }
 
                 } else {
 
-                    reportError(errorHandler, "Invalid initial value for '" + ivs.qname + "' on element '" + isd_element.kind);
+                    outs.push('none');
 
                 }
+
+                isd_element.styleAttrs[sa.qname] = outs;
+
+            } else if (sa.qname === imscStyles.byName.fontSize.qname &&
+                !(sa.qname in isd_element.styleAttrs) &&
+                isd_element.kind === 'span' &&
+                isd_element.styleAttrs[imscStyles.byName.ruby.qname] === 'textContainer') {
+
+                /* special inheritance rule for ruby text container font size */
+
+                var ruby_fs = parent.styleAttrs[imscStyles.byName.fontSize.qname];
+
+                isd_element.styleAttrs[sa.qname] = new imscUtils.ComputedLength(
+                    0.5 * ruby_fs.rw,
+                    0.5 * ruby_fs.rh);
+
+            } else if (sa.qname === imscStyles.byName.fontSize.qname &&
+                !(sa.qname in isd_element.styleAttrs) &&
+                isd_element.kind === 'span' &&
+                isd_element.styleAttrs[imscStyles.byName.ruby.qname] === 'text') {
+
+                /* special inheritance rule for ruby text font size */
+
+                var parent_fs = parent.styleAttrs[imscStyles.byName.fontSize.qname];
+
+                if (parent.styleAttrs[imscStyles.byName.ruby.qname] === 'textContainer') {
+
+                    isd_element.styleAttrs[sa.qname] = parent_fs;
+
+                } else {
+
+                    isd_element.styleAttrs[sa.qname] = new imscUtils.ComputedLength(
+                        0.5 * parent_fs.rw,
+                        0.5 * parent_fs.rh);
+                }
+
+            } else if (sa.inherit &&
+                (sa.qname in parent.styleAttrs) &&
+                !(sa.qname in isd_element.styleAttrs)) {
+
+                isd_element.styleAttrs[sa.qname] = parent.styleAttrs[sa.qname];
 
             }
 
         }
 
-        /* compute styles (only for non-inherited styles) */
-        /* TODO: get rid of spec_attr */
+    }
 
-        for (var z = 0; z < imscStyles.all.length; z++) {
-            
-            var cs = imscStyles.all[z];
+    /* initial value styling */
 
-            if (!(cs.qname in spec_attr)) continue;
+    for (var k = 0; k < imscStyles.all.length; k++) {
 
-            if (cs.compute !== null) {
+        var ivs = imscStyles.all[k];
 
-                var cstyle = cs.compute(
+        /* skip if value is already specified */
+
+        if (ivs.qname in isd_element.styleAttrs) continue;
+
+        /* skip tts:position if tts:origin is specified */
+
+        if (ivs.qname === imscStyles.byName.position.qname &&
+            imscStyles.byName.origin.qname in isd_element.styleAttrs)
+            continue;
+
+        /* skip tts:origin if tts:position is specified */
+
+        if (ivs.qname === imscStyles.byName.origin.qname &&
+            imscStyles.byName.position.qname in isd_element.styleAttrs)
+            continue;
+
+        /* determine initial value */
+
+        var iv = doc.head.styling.initials[ivs.qname] || ivs.initial;
+
+        if (iv === null) {
+            /* skip processing if no initial value defined */
+
+            continue;
+        }
+
+        /* apply initial value to elements other than region only if non-inherited */
+
+        if (isd_element.kind === 'region' || (ivs.inherit === false && iv !== null)) {
+
+            var piv = ivs.parse(iv);
+
+            if (piv !== null) {
+
+                isd_element.styleAttrs[ivs.qname] = piv;
+
+                /* keep track of the style as specified */
+
+                spec_attr[ivs.qname] = true;
+
+            } else {
+
+                reportError(errorHandler, 'Invalid initial value for \'' + ivs.qname + '\' on element \'' + isd_element.kind);
+
+            }
+
+        }
+
+    }
+
+    /* compute styles (only for non-inherited styles) */
+    /* TODO: get rid of spec_attr */
+
+    for (var z = 0; z < imscStyles.all.length; z++) {
+
+        var cs = imscStyles.all[z];
+
+        if (!(cs.qname in spec_attr)) continue;
+
+        if (cs.compute !== null) {
+
+            var cstyle = cs.compute(
+                /*doc, parent, element, attr, context*/
+                doc,
+                parent,
+                isd_element,
+                isd_element.styleAttrs[cs.qname],
+                context
+            );
+
+            if (cstyle !== null) {
+
+                isd_element.styleAttrs[cs.qname] = cstyle;
+
+            } else {
+                /* if the style cannot be computed, replace it by its initial value */
+
+                isd_element.styleAttrs[cs.qname] = cs.compute(
                     /*doc, parent, element, attr, context*/
                     doc,
                     parent,
                     isd_element,
-                    isd_element.styleAttrs[cs.qname],
+                    cs.parse(cs.initial),
                     context
-                    );
+                );
 
-                if (cstyle !== null) {
-
-                    isd_element.styleAttrs[cs.qname] = cstyle;
-                    
-                } else {
-                    /* if the style cannot be computed, replace it by its initial value */
-
-                    isd_element.styleAttrs[cs.qname] = cs.compute(
-                        /*doc, parent, element, attr, context*/
-                        doc,
-                        parent,
-                        isd_element,
-                        cs.parse(cs.initial),
-                        context
-                    );
-
-                    reportError(errorHandler, "Style '" + cs.qname + "' on element '" + isd_element.kind + "' cannot be computed");
-                }
+                reportError(errorHandler, 'Style \'' + cs.qname + '\' on element \'' + isd_element.kind + '\' cannot be computed');
             }
+        }
+
+    }
+
+    /* prune if tts:display is none */
+
+    if (isd_element.styleAttrs[imscStyles.byName.display.qname] === 'none')
+        return null;
+
+    /* process contents of the element */
+
+    var contents = null;
+
+    if (parent === null) {
+
+        /* we are processing the region */
+
+        if (body === null) {
+
+            /* if there is no body, still process the region but with empty content */
+
+            contents = [];
+
+        } else {
+
+            /*use the body element as contents */
+
+            contents = [body];
 
         }
 
-        /* prune if tts:display is none */
+    } else if ('contents' in elem) {
 
-        if (isd_element.styleAttrs[imscStyles.byName.display.qname] === "none")
-            return null;
+        contents = elem.contents;
 
-        /* process contents of the element */
+    }
 
-        var contents = null;
+    for (var x = 0; contents !== null && x < contents.length; x++) {
 
-        if (parent === null) {
+        var c = isdProcessContentElement(doc, offset, region, body, isd_element, associated_region_id, contents[x], errorHandler, context);
 
-            /* we are processing the region */
-
-            if (body === null) {
-
-                /* if there is no body, still process the region but with empty content */
-
-                contents = [];
-
-            } else {
-
-                /*use the body element as contents */
-
-                contents = [body];
-
-            }
-
-        } else if ('contents' in elem) {
-
-            contents = elem.contents;
-
-        }
-
-        for (var x = 0; contents !== null && x < contents.length; x++) {
-
-            var c = isdProcessContentElement(doc, offset, region, body, isd_element, associated_region_id, contents[x], errorHandler, context);
-
-            /* 
-             * keep child element only if they are non-null and their region match 
-             * the region of this element
-             */
-
-            if (c !== null) {
-
-                isd_element.contents.push(c.element);
-
-            }
-
-        }
-
-        /* remove styles that are not applicable */
-
-        for (var qnameb in isd_element.styleAttrs) {
-            if (!isd_element.styleAttrs.hasOwnProperty(qnameb)) continue;
-
-            /* true if not applicable */
-
-            var na = false;
-
-            /* special applicability of certain style properties to ruby container spans */
-            /* TODO: in the future ruby elements should be translated to elements instead of kept as spans */
-
-            if (isd_element.kind === 'span') {
-
-                var rsp = isd_element.styleAttrs[imscStyles.byName.ruby.qname];
-
-                na = ( rsp === 'container' || rsp === 'textContainer' || rsp === 'baseContainer' ) && 
-                    _rcs_na_styles.indexOf(qnameb) !== -1;
-
-                if (! na) {
-
-                    na = rsp !== 'container' &&
-                        qnameb === imscStyles.byName.rubyAlign.qname;
-
-                }
-
-                if (! na) {
-
-                    na =  (! (rsp === 'textContainer' || rsp === 'text')) &&
-                        qnameb === imscStyles.byName.rubyPosition.qname;
-
-                }
-
-            }
-
-            /* normal applicability */
-            
-            if (! na) {
-
-                var da = imscStyles.byQName[qnameb];
-
-                if ("applies" in da){
-
-                    na = da.applies.indexOf(isd_element.kind) === -1;
-
-                }
-
-            }
-
-
-            if (na) {
-                delete isd_element.styleAttrs[qnameb];
-            }
-
-        }
-
-        /* trim whitespace around explicit line breaks */
-
-        var ruby = isd_element.styleAttrs[imscStyles.byName.ruby.qname];
-
-        if (isd_element.kind === 'p' ||
-            (isd_element.kind === 'span' && (ruby === "textContainer" || ruby === "text"))
-            ) {
-
-            var elist = [];
-
-            constructSpanList(isd_element, elist);
-
-            collapseLWSP(elist);
-
-            pruneEmptySpans(isd_element);
-
-        }
-
-        /* keep element if:
-         * * contains a background image
-         * * <br/>
-         * * if there are children
-         * * if it is an image
-         * * if <span> and has text
-         * * if region and showBackground = always
+        /*
+         * keep child element only if they are non-null and their region match
+         * the region of this element
          */
 
-        if ((isd_element.kind === 'div' && imscStyles.byName.backgroundImage.qname in isd_element.styleAttrs) ||
-            isd_element.kind === 'br' ||
-            isd_element.kind === 'image' ||
-            ('contents' in isd_element && isd_element.contents.length > 0) ||
-            (isd_element.kind === 'span' && isd_element.text !== null) ||
-            (isd_element.kind === 'region' &&
-                isd_element.styleAttrs[imscStyles.byName.showBackground.qname] === 'always')) {
+        if (c !== null) {
 
-            return {
-                region_id: associated_region_id,
-                element: isd_element
-            };
-        }
-
-        return null;
-    }
-
-    function collapseLWSP(elist) {
-
-        function isPrevCharLWSP(prev_element) {
-            return prev_element.kind === 'br' || /[\r\n\t ]$/.test(prev_element.text);
-        }
-
-        function isNextCharLWSP(next_element) {
-            return next_element.kind === 'br' || (next_element.space === "preserve" && /^[\r\n]/.test(next_element.text));
-        }
-
-        /* collapse spaces and remove leading LWSPs */
-
-        var element;
-
-        for (var i = 0; i < elist.length;) {
-
-            element = elist[i];
-
-            if (element.kind === "br" || element.space === "preserve") {
-                i++;
-                continue;
-            }
-
-            var trimmed_text = element.text.replace(/[\t\r\n ]+/g, ' ');
-
-            if (/^[ ]/.test(trimmed_text)) {
-
-                if (i === 0 || isPrevCharLWSP(elist[i - 1])) {
-                    trimmed_text = trimmed_text.substring(1);
-                }
-
-            }
-
-            element.text = trimmed_text;
-
-            if (trimmed_text.length === 0) {
-                elist.splice(i, 1);
-            } else {
-                i++;
-            }
-
-        }
-
-        /* remove trailing LWSPs */
-
-        for (i = 0; i < elist.length; i++) {
-
-            element = elist[i];
-
-            if (element.kind === "br" || element.space === "preserve") {
-                i++;
-                continue;
-            }
-
-            if (/[ ]$/.test(element.text)) {
-
-                if (i === (elist.length - 1) || isNextCharLWSP(elist[i + 1])) {
-                    element.text = element.text.slice(0, -1);
-                }
-
-            }
+            isd_element.contents.push(c.element);
 
         }
 
     }
 
-    function constructSpanList(element, elist) {
+    /* remove styles that are not applicable */
 
-        if (! ("contents" in element)) {
-            return;
-        }
+    for (var qnameb in isd_element.styleAttrs) {
+        if (!imscUtils.checkHasOwnProperty(isd_element.styleAttrs, qnameb)) continue;
 
-        for (var i = 0; i < element.contents.length; i++) {
+        /* true if not applicable */
 
-            var child = element.contents[i];
-            var ruby = child.styleAttrs[imscStyles.byName.ruby.qname];
+        var na = false;
 
-            if (child.kind === 'span' && (ruby === "textContainer" || ruby === "text")) {
+        /* special applicability of certain style properties to ruby container spans */
+        /* TODO: in the future ruby elements should be translated to elements instead of kept as spans */
 
-                /* skip ruby text and text containers, which are handled on their own */
-            
-                continue;
+        if (isd_element.kind === 'span') {
 
-            } else if ('contents' in child) {
-    
-                constructSpanList(child, elist);
-    
-            } else if ((child.kind === 'span' && child.text.length !== 0) || child.kind === 'br') {
+            var rsp = isd_element.styleAttrs[imscStyles.byName.ruby.qname];
 
-                /* skip empty spans */
+            na = (rsp === 'container' || rsp === 'textContainer' || rsp === 'baseContainer') &&
+                _rcs_na_styles.indexOf(qnameb) !== -1;
 
-                elist.push(child);
+            if (!na) {
+
+                na = rsp !== 'container' &&
+                    qnameb === imscStyles.byName.rubyAlign.qname;
+
+            }
+
+            if (!na) {
+
+                na = (!(rsp === 'textContainer' || rsp === 'text')) &&
+                    qnameb === imscStyles.byName.rubyPosition.qname;
 
             }
 
         }
 
-    }
+        /* normal applicability */
 
-    function pruneEmptySpans(element) {
+        if (!na) {
 
-        if (element.kind === 'br') {
+            var da = imscStyles.byQName[qnameb];
 
-            return false;
+            if ('applies' in da) {
 
-        } else if ('text' in element) {
-
-            return  element.text.length === 0;
-
-        } else if ('contents' in element) {
-
-            var i = element.contents.length;
-
-            while (i--) {
-
-                if (pruneEmptySpans(element.contents[i])) {
-                    element.contents.splice(i, 1);
-                }
+                na = da.applies.indexOf(isd_element.kind) === -1;
 
             }
 
-            return element.contents.length === 0;
-
         }
+
+
+        if (na) {
+            delete isd_element.styleAttrs[qnameb];
+        }
+
     }
 
-    function ISD(tt) {
-        this.contents = [];
-        this.aspectRatio = tt.aspectRatio;
-        this.lang = tt.lang;
+    /* trim whitespace around explicit line breaks */
+
+    var ruby = isd_element.styleAttrs[imscStyles.byName.ruby.qname];
+
+    if (isd_element.kind === 'p' ||
+        (isd_element.kind === 'span' && (ruby === 'textContainer' || ruby === 'text'))
+    ) {
+
+        var elist = [];
+
+        constructSpanList(isd_element, elist);
+
+        collapseLWSP(elist);
+
+        pruneEmptySpans(isd_element);
+
     }
 
-    function ISDContentElement(ttelem) {
-
-        /* assume the element is a region if it does not have a kind */
-
-        this.kind = ttelem.kind || 'region';
-
-        /* copy lang */
-
-        this.lang = ttelem.lang;
-
-        /* copy id */
-
-        if (ttelem.id) {
-            this.id = ttelem.id;
-        }
-
-        /* deep copy of style attributes */
-        this.styleAttrs = {};
-
-        for (var sname in ttelem.styleAttrs) {
-
-            if (! ttelem.styleAttrs.hasOwnProperty(sname)) continue;
-
-            this.styleAttrs[sname] =
-                ttelem.styleAttrs[sname];
-        }
-        
-        /* copy src and type if image */
-        
-        if ('src' in ttelem) {
-            
-            this.src = ttelem.src;
-            
-        }
-        
-         if ('type' in ttelem) {
-            
-            this.type = ttelem.type;
-            
-        }
-
-        /* TODO: clean this! 
-         * TODO: ISDElement and document element should be better tied together */
-
-        if ('text' in ttelem) {
-
-            this.text = ttelem.text;
-
-        } else if (this.kind === 'region' || 'contents' in ttelem) {
-
-            this.contents = [];
-        }
-
-        if ('space' in ttelem) {
-
-            this.space = ttelem.space;
-        }
-    }
-
-
-    /*
-     * ERROR HANDLING UTILITY FUNCTIONS
-     * 
+    /* keep element if:
+     * * contains a background image
+     * * <br/>
+     * * if there are children
+     * * if it is an image
+     * * if <span> and has text
+     * * if region and showBackground = always
      */
 
-    function reportInfo(errorHandler, msg) {
+    if ((isd_element.kind === 'div' && imscStyles.byName.backgroundImage.qname in isd_element.styleAttrs) ||
+        isd_element.kind === 'br' ||
+        isd_element.kind === 'image' ||
+        ('contents' in isd_element && isd_element.contents.length > 0) ||
+        (isd_element.kind === 'span' && isd_element.text !== null) ||
+        (isd_element.kind === 'region' &&
+            isd_element.styleAttrs[imscStyles.byName.showBackground.qname] === 'always')) {
 
-        if (errorHandler && errorHandler.info && errorHandler.info(msg))
-            throw msg;
+        return {
+            region_id: associated_region_id,
+            element: isd_element
+        };
+    }
+
+    return null;
+}
+
+function collapseLWSP(elist) {
+
+    function isPrevCharLWSP(prev_element) {
+        return prev_element.kind === 'br' || /[\r\n\t ]$/.test(prev_element.text);
+    }
+
+    function isNextCharLWSP(next_element) {
+        return next_element.kind === 'br' || (next_element.space === 'preserve' && /^[\r\n]/.test(next_element.text));
+    }
+
+    /* collapse spaces and remove leading LWSPs */
+
+    var element;
+
+    for (var i = 0; i < elist.length;) {
+
+        element = elist[i];
+
+        if (element.kind === 'br' || element.space === 'preserve') {
+            i++;
+            continue;
+        }
+
+        var trimmed_text = element.text.replace(/[\t\r\n ]+/g, ' ');
+
+        if (/^[ ]/.test(trimmed_text)) {
+
+            if (i === 0 || isPrevCharLWSP(elist[i - 1])) {
+                trimmed_text = trimmed_text.substring(1);
+            }
+
+        }
+
+        element.text = trimmed_text;
+
+        if (trimmed_text.length === 0) {
+            elist.splice(i, 1);
+        } else {
+            i++;
+        }
 
     }
 
-    function reportWarning(errorHandler, msg) {
+    /* remove trailing LWSPs */
 
-        if (errorHandler && errorHandler.warn && errorHandler.warn(msg))
-            throw msg;
+    for (i = 0; i < elist.length; i++) {
+
+        element = elist[i];
+
+        if (element.kind === 'br' || element.space === 'preserve') {
+            i++;
+            continue;
+        }
+
+        if (/[ ]$/.test(element.text)) {
+
+            if (i === (elist.length - 1) || isNextCharLWSP(elist[i + 1])) {
+                element.text = element.text.slice(0, -1);
+            }
+
+        }
 
     }
 
-    function reportError(errorHandler, msg) {
+}
 
-        if (errorHandler && errorHandler.error && errorHandler.error(msg))
-            throw msg;
+function constructSpanList(element, elist) {
+
+    if (!('contents' in element)) {
+        return;
+    }
+
+    for (var i = 0; i < element.contents.length; i++) {
+
+        var child = element.contents[i];
+        var ruby = child.styleAttrs[imscStyles.byName.ruby.qname];
+
+        if (child.kind === 'span' && (ruby === 'textContainer' || ruby === 'text')) {
+
+            /* skip ruby text and text containers, which are handled on their own */
+
+            continue;
+
+        } else if ('contents' in child) {
+
+            constructSpanList(child, elist);
+
+        } else if ((child.kind === 'span' && child.text.length !== 0) || child.kind === 'br') {
+
+            /* skip empty spans */
+
+            elist.push(child);
+
+        }
 
     }
 
-    function reportFatal(errorHandler, msg) {
+}
 
-        if (errorHandler && errorHandler.fatal)
-            errorHandler.fatal(msg);
+function pruneEmptySpans(element) {
 
+    if (element.kind === 'br') {
+
+        return false;
+
+    } else if ('text' in element) {
+
+        return element.text.length === 0;
+
+    } else if ('contents' in element) {
+
+        var i = element.contents.length;
+
+        while (i--) {
+
+            if (pruneEmptySpans(element.contents[i])) {
+                element.contents.splice(i, 1);
+            }
+
+        }
+
+        return element.contents.length === 0;
+
+    }
+}
+
+function ISD(tt) {
+    this.contents = [];
+    this.aspectRatio = tt.aspectRatio;
+    this.lang = tt.lang;
+}
+
+function ISDContentElement(ttelem) {
+
+    /* assume the element is a region if it does not have a kind */
+
+    this.kind = ttelem.kind || 'region';
+
+    /* copy lang */
+
+    this.lang = ttelem.lang;
+
+    /* copy id */
+
+    if (ttelem.id) {
+        this.id = ttelem.id;
+    }
+
+    /* deep copy of style attributes */
+    this.styleAttrs = {};
+
+    for (var sname in ttelem.styleAttrs) {
+
+        if (!imscUtils.checkHasOwnProperty(ttelem.styleAttrs, sname)) continue;
+
+        this.styleAttrs[sname] =
+            ttelem.styleAttrs[sname];
+    }
+
+    /* copy src and type if image */
+
+    if ('src' in ttelem) {
+
+        this.src = ttelem.src;
+
+    }
+
+    if ('type' in ttelem) {
+
+        this.type = ttelem.type;
+
+    }
+
+    /* TODO: clean this!
+     * TODO: ISDElement and document element should be better tied together */
+
+    if ('text' in ttelem) {
+
+        this.text = ttelem.text;
+
+    } else if (this.kind === 'region' || 'contents' in ttelem) {
+
+        this.contents = [];
+    }
+
+    if ('space' in ttelem) {
+
+        this.space = ttelem.space;
+    }
+}
+
+
+/*
+ * ERROR HANDLING UTILITY FUNCTIONS
+ * (not used, comments left)
+ */
+
+// function reportInfo(errorHandler, msg) {
+//
+//     if (errorHandler && errorHandler.info && errorHandler.info(msg))
+//         throw msg;
+//
+// }
+
+// function reportWarning(errorHandler, msg) {
+//
+//     if (errorHandler && errorHandler.warn && errorHandler.warn(msg))
+//         throw msg;
+//
+// }
+
+function reportError(errorHandler, msg) {
+
+    if (errorHandler && errorHandler.error && errorHandler.error(msg))
         throw msg;
 
-    }
+}
 
+// function reportFatal(errorHandler, msg) {
+//
+//     if (errorHandler && errorHandler.fatal)
+//         errorHandler.fatal(msg);
+//
+//     throw msg;
+//
+// }
 
-})(typeof exports === 'undefined' ? this.imscISD = {} : exports,
-    typeof imscNames === 'undefined' ? require("./names") : imscNames,
-    typeof imscStyles === 'undefined' ? require("./styles") : imscStyles,
-    typeof imscUtils === 'undefined' ? require("./utils") : imscUtils
-    );
+module.exports = imscISD;

--- a/src/main/js/names.js
+++ b/src/main/js/names.js
@@ -28,20 +28,13 @@
  * @module imscNames
  */
 
-;
-(function (imscNames) { // wrapper for non-node envs
-
-    imscNames.ns_tt = "http://www.w3.org/ns/ttml";
-    imscNames.ns_tts = "http://www.w3.org/ns/ttml#styling";
-    imscNames.ns_ttp = "http://www.w3.org/ns/ttml#parameter";
-    imscNames.ns_xml = "http://www.w3.org/XML/1998/namespace";
-    imscNames.ns_itts = "http://www.w3.org/ns/ttml/profile/imsc1#styling";
-    imscNames.ns_ittp = "http://www.w3.org/ns/ttml/profile/imsc1#parameter";
-    imscNames.ns_smpte = "http://www.smpte-ra.org/schemas/2052-1/2010/smpte-tt";
-    imscNames.ns_ebutts = "urn:ebu:tt:style";
-    
-})(typeof exports === 'undefined' ? this.imscNames = {} : exports);
-
-
+exports.ns_tt = 'http://www.w3.org/ns/ttml';
+exports.ns_tts = 'http://www.w3.org/ns/ttml#styling';
+exports.ns_ttp = 'http://www.w3.org/ns/ttml#parameter';
+exports.ns_xml = 'http://www.w3.org/XML/1998/namespace';
+exports.ns_itts = 'http://www.w3.org/ns/ttml/profile/imsc1#styling';
+exports.ns_ittp = 'http://www.w3.org/ns/ttml/profile/imsc1#parameter';
+exports.ns_smpte = 'http://www.smpte-ra.org/schemas/2052-1/2010/smpte-tt';
+exports.ns_ebutts = 'urn:ebu:tt:style';
 
 

--- a/src/main/js/styles.js
+++ b/src/main/js/styles.js
@@ -28,185 +28,180 @@
  * @module imscStyles
  */
 
-;
-(function (imscStyles, imscNames, imscUtils) { // wrapper for non-node envs
+const imscNames = require('./names');
+const imscUtils = require('./utils');
+const imscStyles = {};
 
-    function StylingAttributeDefinition(ns, name, initialValue, appliesTo, isInherit, isAnimatable, parseFunc, computeFunc) {
-        this.name = name;
-        this.ns = ns;
-        this.qname = ns + " " + name;
-        this.inherit = isInherit;
-        this.animatable = isAnimatable;
-        this.initial = initialValue;
-        this.applies = appliesTo;
-        this.parse = parseFunc;
-        this.compute = computeFunc;
-    }
+function StylingAttributeDefinition(ns, name, initialValue, appliesTo, isInherit, isAnimatable, parseFunc, computeFunc) {
+    this.name = name;
+    this.ns = ns;
+    this.qname = ns + ' ' + name;
+    this.inherit = isInherit;
+    this.animatable = isAnimatable;
+    this.initial = initialValue;
+    this.applies = appliesTo;
+    this.parse = parseFunc;
+    this.compute = computeFunc;
+}
 
-    imscStyles.all = [
+imscStyles.all = [
 
-        new StylingAttributeDefinition(
-            imscNames.ns_tts,
-            "backgroundColor",
-            "transparent",
-            ['body', 'div', 'p', 'region', 'span'],
-            false,
-            true,
-            imscUtils.parseColor,
-            null
-            ),
-        new StylingAttributeDefinition(
-            imscNames.ns_tts,
-            "color",
-            "white",
-            ['span'],
-            true,
-            true,
-            imscUtils.parseColor,
-            null
-            ),
-        new StylingAttributeDefinition(
-            imscNames.ns_tts,
-            "direction",
-            "ltr",
-            ['p', 'span'],
-            true,
-            true,
-            function (str) {
+    new StylingAttributeDefinition(
+        imscNames.ns_tts,
+        'backgroundColor',
+        'transparent',
+        ['body', 'div', 'p', 'region', 'span'],
+        false,
+        true,
+        imscUtils.parseColor,
+        null
+    ),
+    new StylingAttributeDefinition(
+        imscNames.ns_tts,
+        'color',
+        'white',
+        ['span'],
+        true,
+        true,
+        imscUtils.parseColor,
+        null
+    ),
+    new StylingAttributeDefinition(
+        imscNames.ns_tts,
+        'direction',
+        'ltr',
+        ['p', 'span'],
+        true,
+        true,
+        function (str) {
+            return str;
+        },
+        null
+    ),
+    new StylingAttributeDefinition(
+        imscNames.ns_tts,
+        'display',
+        'auto',
+        ['body', 'div', 'p', 'region', 'span'],
+        false,
+        true,
+        function (str) {
+            return str;
+        },
+        null
+    ),
+    new StylingAttributeDefinition(
+        imscNames.ns_tts,
+        'displayAlign',
+        'before',
+        ['region'],
+        false,
+        true,
+        function (str) {
+            return str;
+        },
+        null
+    ),
+    new StylingAttributeDefinition(
+        imscNames.ns_tts,
+        'extent',
+        'auto',
+        ['tt', 'region'],
+        false,
+        true,
+        function (str) {
+
+            if (str === 'auto') {
+
                 return str;
-            },
-            null
-            ),
-        new StylingAttributeDefinition(
-            imscNames.ns_tts,
-            "display",
-            "auto",
-            ['body', 'div', 'p', 'region', 'span'],
-            false,
-            true,
-            function (str) {
-                return str;
-            },
-            null
-            ),
-        new StylingAttributeDefinition(
-            imscNames.ns_tts,
-            "displayAlign",
-            "before",
-            ['region'],
-            false,
-            true,
-            function (str) {
-                return str;
-            },
-            null
-            ),
-        new StylingAttributeDefinition(
-            imscNames.ns_tts,
-            "extent",
-            "auto",
-            ['tt', 'region'],
-            false,
-            true,
-            function (str) {
 
-                if (str === "auto") {
+            } else {
 
-                    return str;
-
-                } else {
-
-                    var s = str.split(" ");
-                    if (s.length !== 2)
-                        return null;
-                    var w = imscUtils.parseLength(s[0]);
-                    var h = imscUtils.parseLength(s[1]);
-                    if (!h || !w)
-                        return null;
-                    return {'h': h, 'w': w};
-                }
-
-            },
-            function (doc, parent, element, attr, context) {
-
-                var h;
-                var w;
-
-                if (attr === "auto") {
-
-                    h = new imscUtils.ComputedLength(0, 1);
-
-                } else {
-
-                    h = imscUtils.toComputedLength(
-                        attr.h.value,
-                        attr.h.unit,
-                        null,
-                        doc.dimensions.h,
-                        null,
-                        doc.pxLength.h
-                        );
-
-
-                    if (h === null) {
-
-                        return null;
-
-                    }
-                }
-
-                if (attr === "auto") {
-
-                    w = new imscUtils.ComputedLength(1, 0);
-
-                } else {
-
-                    w = imscUtils.toComputedLength(
-                        attr.w.value,
-                        attr.w.unit,
-                        null,
-                        doc.dimensions.w,
-                        null,
-                        doc.pxLength.w
-                        );
-
-                    if (w === null) {
-
-                        return null;
-
-                    }
-
-                }
-
+                var s = str.split(' ');
+                if (s.length !== 2)
+                    return null;
+                var w = imscUtils.parseLength(s[0]);
+                var h = imscUtils.parseLength(s[1]);
+                if (!h || !w)
+                    return null;
                 return {'h': h, 'w': w};
             }
-        ),
-        new StylingAttributeDefinition(
-            imscNames.ns_tts,
-            "fontFamily",
-            "default",
-            ['span', 'p'],
-            true,
-            true,
-            function (str) {
-                var ffs = str.split(",");
-                var rslt = [];
 
-                for (var i = 0; i < ffs.length; i++) {
+        },
+        function (doc, parent, element, attr) {
 
-                    if (ffs[i].charAt(0) !== "'" && ffs[i].charAt(0) !== '"') {
+            var h;
+            var w;
 
-                        if (ffs[i] === "default") {
+            if (attr === 'auto') {
 
-                            /* per IMSC1 */
+                h = new imscUtils.ComputedLength(0, 1);
 
-                            rslt.push("monospaceSerif");
+            } else {
 
-                        } else {
+                h = imscUtils.toComputedLength(
+                    attr.h.value,
+                    attr.h.unit,
+                    null,
+                    doc.dimensions.h,
+                    null,
+                    doc.pxLength.h
+                );
 
-                            rslt.push(ffs[i]);
 
-                        }
+                if (h === null) {
+
+                    return null;
+
+                }
+            }
+
+            if (attr === 'auto') {
+
+                w = new imscUtils.ComputedLength(1, 0);
+
+            } else {
+
+                w = imscUtils.toComputedLength(
+                    attr.w.value,
+                    attr.w.unit,
+                    null,
+                    doc.dimensions.w,
+                    null,
+                    doc.pxLength.w
+                );
+
+                if (w === null) {
+
+                    return null;
+
+                }
+
+            }
+
+            return {'h': h, 'w': w};
+        }
+    ),
+    new StylingAttributeDefinition(
+        imscNames.ns_tts,
+        'fontFamily',
+        'default',
+        ['span', 'p'],
+        true,
+        true,
+        function (str) {
+            var ffs = str.split(',');
+            var rslt = [];
+
+            for (var i = 0; i < ffs.length; i++) {
+
+                if (ffs[i].charAt(0) !== '\'' && ffs[i].charAt(0) !== '"') {
+
+                    if (ffs[i] === 'default') {
+
+                        /* per IMSC1 */
+
+                        rslt.push('monospaceSerif');
 
                     } else {
 
@@ -214,1002 +209,1005 @@
 
                     }
 
-                }
-
-                return rslt;
-            },
-            null
-            ),
-        new StylingAttributeDefinition(
-            imscNames.ns_tts,
-            "shear",
-            "0%",
-            ['p'],
-            true,
-            true,
-            imscUtils.parseLength,
-            function (doc, parent, element, attr) {
-
-                var fs;
-
-                if (attr.unit === "%") {
-
-                    fs = Math.abs(attr.value) > 100 ? Math.sign(attr.value) * 100 : attr.value;
-
                 } else {
 
-                    return null;
+                    rslt.push(ffs[i]);
 
                 }
 
-                return fs;
             }
-        ),
-        new StylingAttributeDefinition(
-            imscNames.ns_tts,
-            "fontSize",
-            "1c",
-            ['span', 'p'],
-            true,
-            true,
-            imscUtils.parseLength,
-            function (doc, parent, element, attr, context) {
 
-                var fs;
-
-                fs = imscUtils.toComputedLength(
-                    attr.value,
-                    attr.unit,
-                    parent !== null ? parent.styleAttrs[imscStyles.byName.fontSize.qname] : doc.cellLength.h,
-                    parent !== null ? parent.styleAttrs[imscStyles.byName.fontSize.qname] : doc.cellLength.h,
-                    doc.cellLength.h,
-                    doc.pxLength.h
-                    );
-
-                return fs;
-            }
-        ),
-        new StylingAttributeDefinition(
-            imscNames.ns_tts,
-            "fontStyle",
-            "normal",
-            ['span', 'p'],
-            true,
-            true,
-            function (str) {
-                /* TODO: handle font style */
-
-                return str;
-            },
-            null
-            ),
-        new StylingAttributeDefinition(
-            imscNames.ns_tts,
-            "fontWeight",
-            "normal",
-            ['span', 'p'],
-            true,
-            true,
-            function (str) {
-                /* TODO: handle font weight */
-
-                return str;
-            },
-            null
-            ),
-        new StylingAttributeDefinition(
-            imscNames.ns_tts,
-            "lineHeight",
-            "normal",
-            ['p'],
-            true,
-            true,
-            function (str) {
-                if (str === "normal") {
-                    return str;
-                } else {
-                    return imscUtils.parseLength(str);
-                }
-            },
-            function (doc, parent, element, attr, context) {
-
-                var lh;
-
-                if (attr === "normal") {
-
-                    /* inherit normal per https://github.com/w3c/ttml1/issues/220 */
-
-                    lh = attr;
-
-                } else {
-
-                    lh = imscUtils.toComputedLength(
-                        attr.value,
-                        attr.unit,
-                        element.styleAttrs[imscStyles.byName.fontSize.qname],
-                        element.styleAttrs[imscStyles.byName.fontSize.qname],
-                        doc.cellLength.h,
-                        doc.pxLength.h
-                        );
-
-                    if (lh === null) {
-
-                        return null;
-
-                    }
-
-                }
-
-                /* TODO: create a Length constructor */
-
-                return lh;
-            }
-        ),
-        new StylingAttributeDefinition(
-            imscNames.ns_tts,
-            "opacity",
-            1.0,
-            ['region'],
-            false,
-            true,
-            parseFloat,
-            null
-            ),
-        new StylingAttributeDefinition(
-            imscNames.ns_tts,
-            "origin",
-            "auto",
-            ['region'],
-            false,
-            true,
-            function (str) {
-
-                if (str === "auto") {
-
-                    return str;
-
-                } else {
-
-                    var s = str.split(" ");
-                    if (s.length !== 2)
-                        return null;
-                    var w = imscUtils.parseLength(s[0]);
-                    var h = imscUtils.parseLength(s[1]);
-                    if (!h || !w)
-                        return null;
-                    return {'h': h, 'w': w};
-                }
-
-            },
-            function (doc, parent, element, attr, context) {
-
-                var h;
-                var w;
-
-                if (attr === "auto") {
-
-                    h = new imscUtils.ComputedLength(0,0);
-
-                } else {
-
-                    h = imscUtils.toComputedLength(
-                        attr.h.value,
-                        attr.h.unit,
-                        null,
-                        doc.dimensions.h,
-                        null,
-                        doc.pxLength.h
-                        );
-
-                    if (h === null) {
-
-                        return null;
-
-                    }
-
-                }
-
-                if (attr === "auto") {
-
-                    w = new imscUtils.ComputedLength(0,0);
-
-                } else {
-
-                    w = imscUtils.toComputedLength(
-                        attr.w.value,
-                        attr.w.unit,
-                        null,
-                        doc.dimensions.w,
-                        null,
-                        doc.pxLength.w
-                        );
-
-                    if (w === null) {
-
-                        return null;
-
-                    }
-
-                }
-
-                return {'h': h, 'w': w};
-            }
-        ),
-        new StylingAttributeDefinition(
-            imscNames.ns_tts,
-            "overflow",
-            "hidden",
-            ['region'],
-            false,
-            true,
-            function (str) {
-                return str;
-            },
-            null
-            ),
-        new StylingAttributeDefinition(
-            imscNames.ns_tts,
-            "padding",
-            "0px",
-            ['region'],
-            false,
-            true,
-            function (str) {
-
-                var s = str.split(" ");
-                if (s.length > 4)
-                    return null;
-                var r = [];
-                for (var i = 0; i < s.length; i++) {
-
-                    var l = imscUtils.parseLength(s[i]);
-                    if (!l)
-                        return null;
-                    r.push(l);
-                }
-
-                return r;
-            },
-            function (doc, parent, element, attr, context) {
-
-                var padding;
-
-                /* TODO: make sure we are in region */
-
-                /*
-                 * expand padding shortcuts to 
-                 * [before, end, after, start]
-                 * 
-                 */
-
-                if (attr.length === 1) {
-
-                    padding = [attr[0], attr[0], attr[0], attr[0]];
-
-                } else if (attr.length === 2) {
-
-                    padding = [attr[0], attr[1], attr[0], attr[1]];
-
-                } else if (attr.length === 3) {
-
-                    padding = [attr[0], attr[1], attr[2], attr[1]];
-
-                } else if (attr.length === 4) {
-
-                    padding = [attr[0], attr[1], attr[2], attr[3]];
-
-                } else {
-
-                    return null;
-
-                }
-
-                /* TODO: take into account tts:direction */
-
-                /* 
-                 * transform [before, end, after, start] according to writingMode to 
-                 * [top,left,bottom,right]
-                 * 
-                 */
-
-                var dir = element.styleAttrs[imscStyles.byName.writingMode.qname];
-
-                if (dir === "lrtb" || dir === "lr") {
-
-                    padding = [padding[0], padding[3], padding[2], padding[1]];
-
-                } else if (dir === "rltb" || dir === "rl") {
-
-                    padding = [padding[0], padding[1], padding[2], padding[3]];
-
-                } else if (dir === "tblr") {
-
-                    padding = [padding[3], padding[0], padding[1], padding[2]];
-
-                } else if (dir === "tbrl" || dir === "tb") {
-
-                    padding = [padding[3], padding[2], padding[1], padding[0]];
-
-                } else {
-
-                    return null;
-
-                }
-
-                var out = [];
-
-                for (var i = 0 ; i < padding.length; i++) {
-
-                    if (padding[i].value === 0) {
-
-                        out[i] = new imscUtils.ComputedLength(0,0);
-
-                    } else {
-
-                        out[i] = imscUtils.toComputedLength(
-                            padding[i].value,
-                            padding[i].unit,
-                            element.styleAttrs[imscStyles.byName.fontSize.qname],
-                            i === 0 || i === 2 ? element.styleAttrs[imscStyles.byName.extent.qname].h : element.styleAttrs[imscStyles.byName.extent.qname].w,
-                            i === 0 || i === 2 ? doc.cellLength.h : doc.cellLength.w,
-                            i === 0 || i === 2 ? doc.pxLength.h: doc.pxLength.w
-                            );
-
-                        if (out[i] === null) return null;
-
-                    }
-                }
-
-
-                return out;
-            }
-        ),
-        new StylingAttributeDefinition(
-            imscNames.ns_tts,
-            "position",
-            "top left",
-            ['region'],
-            false,
-            true,
-            function (str) {
-
-                return imscUtils.parsePosition(str);
-
-            },
-            function (doc, parent, element, attr) {
-                var h;
-                var w;
-                
-                h = imscUtils.toComputedLength(
-                    attr.v.offset.value,
-                    attr.v.offset.unit,
-                    null,
-                    new imscUtils.ComputedLength(
-                        - element.styleAttrs[imscStyles.byName.extent.qname].h.rw,
-                        doc.dimensions.h.rh - element.styleAttrs[imscStyles.byName.extent.qname].h.rh 
-                    ),
-                    null,
-                    doc.pxLength.h
-                    );
-
-                if (h === null) return null;
-
-
-                if (attr.v.edge === "bottom") {
-
-                    h = new imscUtils.ComputedLength(
-                        - h.rw - element.styleAttrs[imscStyles.byName.extent.qname].h.rw,
-                        doc.dimensions.h.rh - h.rh - element.styleAttrs[imscStyles.byName.extent.qname].h.rh
-                    );
-            
-                }
-
-                w = imscUtils.toComputedLength(
-                    attr.h.offset.value,
-                    attr.h.offset.unit,
-                    null,
-                    new imscUtils.ComputedLength(
-                        doc.dimensions.w.rw - element.styleAttrs[imscStyles.byName.extent.qname].w.rw,
-                        - element.styleAttrs[imscStyles.byName.extent.qname].w.rh
-                    ),
-                    null,
-                    doc.pxLength.w
-                    );
-
-                if (h === null) return null;
-
-                if (attr.h.edge === "right") {
-                    
-                    w = new imscUtils.ComputedLength(
-                        doc.dimensions.w.rw - w.rw - element.styleAttrs[imscStyles.byName.extent.qname].w.rw,
-                        - w.rh - element.styleAttrs[imscStyles.byName.extent.qname].w.rh
-                    );
-
-                }
-
-                return {'h': h, 'w': w};
-            }
-        ),
-        new StylingAttributeDefinition(
-            imscNames.ns_tts,
-            "ruby",
-            "none",
-            ['span'],
-            false,
-            true,
-            function (str) {
-                return str;
-            },
-            null
-            ),
-        new StylingAttributeDefinition(
-            imscNames.ns_tts,
-            "rubyAlign",
-            "center",
-            ['span'],
-            true,
-            true,
-            function (str) {
-                
-                if (! (str === "center" || str === "spaceAround")) {
-                    return null;
-                }
-                
-                return str;
-            },
-            null
-            ),
-        new StylingAttributeDefinition(
-            imscNames.ns_tts,
-            "rubyPosition",
-            "outside",
-            ['span'],
-            true,
-            true,
-            function (str) {
-                return str;
-            },
-            null
-            ),
-        new StylingAttributeDefinition(
-            imscNames.ns_tts,
-            "rubyReserve",
-            "none",
-            ['p'],
-            true,
-            true,
-            function (str) {
-                var s = str.split(" ");
-
-                var r = [null, null];
-
-                if (s.length === 0 || s.length > 2)
-                    return null;
-
-                if (s[0] === "none" ||
-                    s[0] === "both" ||
-                    s[0] === "after" ||
-                    s[0] === "before" ||
-                    s[0] === "outside") {
-
-                    r[0] = s[0];
-
-                } else {
-
-                    return null;
-
-                }
-
-                if (s.length === 2 && s[0] !== "none") {
-
-                    var l = imscUtils.parseLength(s[1]);
-
-                    if (l) {
-
-                        r[1] = l;
-
-                    } else {
-
-                        return null;
-
-                    }
-
-                }
-
-
-                return r;
-            },
-            function (doc, parent, element, attr, context) {
-
-                if (attr[0] === "none") {
-
-                    return attr;
-
-                }
-
-                var fs = null;
-
-                if (attr[1] === null) {
-
-                    fs = new imscUtils.ComputedLength(
-                            element.styleAttrs[imscStyles.byName.fontSize.qname].rw * 0.5,
-                            element.styleAttrs[imscStyles.byName.fontSize.qname].rh * 0.5
-                    );
-
-                } else {
-
-                    fs = imscUtils.toComputedLength(attr[1].value,
-                        attr[1].unit,
-                        element.styleAttrs[imscStyles.byName.fontSize.qname],
-                        element.styleAttrs[imscStyles.byName.fontSize.qname],
-                        doc.cellLength.h,
-                        doc.pxLength.h
-                        );
-                
-                }
-
-                if (fs === null) return null;
-
-                return [attr[0], fs];
-            }
-        ),
-        new StylingAttributeDefinition(
-            imscNames.ns_tts,
-            "showBackground",
-            "always",
-            ['region'],
-            false,
-            true,
-            function (str) {
-                return str;
-            },
-            null
-            ),
-        new StylingAttributeDefinition(
-            imscNames.ns_tts,
-            "textAlign",
-            "start",
-            ['p'],
-            true,
-            true,
-            function (str) {
-                return str;
-            },
-            function (doc, parent, element, attr, context) {
-                /* Section 7.16.9 of XSL */
-
-                if (attr === "left") {
-
-                    return "start";
-
-                } else if (attr === "right") {
-
-                    return "end";
-
-                } else {
-
-                    return attr;
-
-                }
-            }
-        ),
-        new StylingAttributeDefinition(
-            imscNames.ns_tts,
-            "textCombine",
-            "none",
-            ['span'],
-            true,
-            true,
-            function (str) {
-                if (str === "none" || str === "all") {
-
-                    return str;
-                }
+            return rslt;
+        },
+        null
+    ),
+    new StylingAttributeDefinition(
+        imscNames.ns_tts,
+        'shear',
+        '0%',
+        ['p'],
+        true,
+        true,
+        imscUtils.parseLength,
+        function (doc, parent, element, attr) {
+
+            var fs;
+
+            if (attr.unit === '%') {
+
+                fs = Math.abs(attr.value) > 100 ? Math.sign(attr.value) * 100 : attr.value;
+
+            } else {
 
                 return null;
-            },
-            null
-            ),
-        new StylingAttributeDefinition(
-            imscNames.ns_tts,
-            "textDecoration",
-            "none",
-            ['span'],
-            true,
-            true,
-            function (str) {
-                return str.split(" ");
-            },
-            null
-            ),
-        new StylingAttributeDefinition(
-            imscNames.ns_tts,
-            "textEmphasis",
-            "none",
-            ['span'],
-            true,
-            true,
-            function (str) {
-                var e = str.split(" ");
 
-                var rslt = {style: null, symbol: null, color: null, position: null};
+            }
 
-                for (var i = 0; i < e.length; i++) {
+            return fs;
+        }
+    ),
+    new StylingAttributeDefinition(
+        imscNames.ns_tts,
+        'fontSize',
+        '1c',
+        ['span', 'p'],
+        true,
+        true,
+        imscUtils.parseLength,
+        function (doc, parent, element, attr) {
 
-                    if (e[i] === "none" || e[i] === "auto") {
+            var fs;
 
-                        rslt.style = e[i];
+            fs = imscUtils.toComputedLength(
+                attr.value,
+                attr.unit,
+                parent !== null ? parent.styleAttrs[imscStyles.byName.fontSize.qname] : doc.cellLength.h,
+                parent !== null ? parent.styleAttrs[imscStyles.byName.fontSize.qname] : doc.cellLength.h,
+                doc.cellLength.h,
+                doc.pxLength.h
+            );
 
-                    } else if (e[i] === "filled" ||
-                        e[i] === "open") {
+            return fs;
+        }
+    ),
+    new StylingAttributeDefinition(
+        imscNames.ns_tts,
+        'fontStyle',
+        'normal',
+        ['span', 'p'],
+        true,
+        true,
+        function (str) {
+            /* TODO: handle font style */
 
-                        rslt.style = e[i];
+            return str;
+        },
+        null
+    ),
+    new StylingAttributeDefinition(
+        imscNames.ns_tts,
+        'fontWeight',
+        'normal',
+        ['span', 'p'],
+        true,
+        true,
+        function (str) {
+            /* TODO: handle font weight */
 
-                    } else if (e[i] === "circle" ||
-                        e[i] === "dot" ||
-                        e[i] === "sesame") {
+            return str;
+        },
+        null
+    ),
+    new StylingAttributeDefinition(
+        imscNames.ns_tts,
+        'lineHeight',
+        'normal',
+        ['p'],
+        true,
+        true,
+        function (str) {
+            if (str === 'normal') {
+                return str;
+            } else {
+                return imscUtils.parseLength(str);
+            }
+        },
+        function (doc, parent, element, attr) {
 
-                        rslt.symbol = e[i];
+            var lh;
 
-                    } else if (e[i] === "current") {
+            if (attr === 'normal') {
 
-                        rslt.color = e[i];
+                /* inherit normal per https://github.com/w3c/ttml1/issues/220 */
 
-                    } else if (e[i] === "outside" || e[i] === "before" || e[i] === "after") {
+                lh = attr;
 
-                        rslt.position = e[i];
+            } else {
 
-                    } else {
-
-                        rslt.color = imscUtils.parseColor(e[i]);
-
-                        if (rslt.color === null)
-                            return null;
-
-                    }
-                }
-
-                if (rslt.style == null && rslt.symbol == null) {
-
-                    rslt.style = "auto";
-
-                } else {
-
-                    rslt.symbol = rslt.symbol || "circle";
-                    rslt.style = rslt.style || "filled";
-
-                }
-
-                rslt.position = rslt.position || "outside";
-                rslt.color = rslt.color || "current";
-
-                return rslt;
-            },
-            null
-            ),
-        new StylingAttributeDefinition(
-            imscNames.ns_tts,
-            "textOutline",
-            "none",
-            ['span'],
-            true,
-            true,
-            function (str) {
-
-                /*
-                 * returns {c: <color>?, thichness: <length>} | "none"
-                 * 
-                 */
-
-                if (str === "none") {
-
-                    return str;
-
-                } else {
-
-                    var r = {};
-                    var s = str.split(" ");
-                    if (s.length === 0 || s.length > 2)
-                        return null;
-                    var c = imscUtils.parseColor(s[0]);
-
-                    r.color = c;
-
-                    if (c !== null)
-                        s.shift();
-
-                    if (s.length !== 1)
-                        return null;
-
-                    var l = imscUtils.parseLength(s[0]);
-
-                    if (!l)
-                        return null;
-
-                    r.thickness = l;
-
-                    return r;
-                }
-
-            },
-            function (doc, parent, element, attr, context) {
-
-                /*
-                 * returns {color: <color>, thickness: <norm length>}
-                 * 
-                 */
-
-                if (attr === "none")
-                    return attr;
-
-                var rslt = {};
-
-                if (attr.color === null) {
-
-                    rslt.color = element.styleAttrs[imscStyles.byName.color.qname];
-
-                } else {
-
-                    rslt.color = attr.color;
-
-                }
-
-                rslt.thickness = imscUtils.toComputedLength(
-                    attr.thickness.value,
-                    attr.thickness.unit,
+                lh = imscUtils.toComputedLength(
+                    attr.value,
+                    attr.unit,
                     element.styleAttrs[imscStyles.byName.fontSize.qname],
                     element.styleAttrs[imscStyles.byName.fontSize.qname],
                     doc.cellLength.h,
                     doc.pxLength.h
-                    );
+                );
 
-                if (rslt.thickness === null)
+                if (lh === null) {
+
                     return null;
 
-                return rslt;
+                }
+
             }
-        ),
-        new StylingAttributeDefinition(
-            imscNames.ns_tts,
-            "textShadow",
-            "none",
-            ['span'],
-            true,
-            true,
-            imscUtils.parseTextShadow,
-            function (doc, parent, element, attr) {
 
-                /*
-                 * returns [{x_off: <length>, y_off: <length>, b_radius: <length>, color: <color>}*] or "none"
-                 * 
-                 */
+            /* TODO: create a Length constructor */
 
-                if (attr === "none")
-                    return attr;
+            return lh;
+        }
+    ),
+    new StylingAttributeDefinition(
+        imscNames.ns_tts,
+        'opacity',
+        1.0,
+        ['region'],
+        false,
+        true,
+        parseFloat,
+        null
+    ),
+    new StylingAttributeDefinition(
+        imscNames.ns_tts,
+        'origin',
+        'auto',
+        ['region'],
+        false,
+        true,
+        function (str) {
 
-                var r = [];
+            if (str === 'auto') {
 
-                for (var i = 0; i < attr.length; i++) {
+                return str;
 
-                    var shadow = {};
+            } else {
 
-                    shadow.x_off = imscUtils.toComputedLength(
-                        attr[i][0].value,
-                        attr[i][0].unit,
-                        null,
+                var s = str.split(' ');
+                if (s.length !== 2)
+                    return null;
+                var w = imscUtils.parseLength(s[0]);
+                var h = imscUtils.parseLength(s[1]);
+                if (!h || !w)
+                    return null;
+                return {'h': h, 'w': w};
+            }
+
+        },
+        function (doc, parent, element, attr) {
+
+            var h;
+            var w;
+
+            if (attr === 'auto') {
+
+                h = new imscUtils.ComputedLength(0, 0);
+
+            } else {
+
+                h = imscUtils.toComputedLength(
+                    attr.h.value,
+                    attr.h.unit,
+                    null,
+                    doc.dimensions.h,
+                    null,
+                    doc.pxLength.h
+                );
+
+                if (h === null) {
+
+                    return null;
+
+                }
+
+            }
+
+            if (attr === 'auto') {
+
+                w = new imscUtils.ComputedLength(0, 0);
+
+            } else {
+
+                w = imscUtils.toComputedLength(
+                    attr.w.value,
+                    attr.w.unit,
+                    null,
+                    doc.dimensions.w,
+                    null,
+                    doc.pxLength.w
+                );
+
+                if (w === null) {
+
+                    return null;
+
+                }
+
+            }
+
+            return {'h': h, 'w': w};
+        }
+    ),
+    new StylingAttributeDefinition(
+        imscNames.ns_tts,
+        'overflow',
+        'hidden',
+        ['region'],
+        false,
+        true,
+        function (str) {
+            return str;
+        },
+        null
+    ),
+    new StylingAttributeDefinition(
+        imscNames.ns_tts,
+        'padding',
+        '0px',
+        ['region'],
+        false,
+        true,
+        function (str) {
+
+            var s = str.split(' ');
+            if (s.length > 4)
+                return null;
+            var r = [];
+            for (var i = 0; i < s.length; i++) {
+
+                var l = imscUtils.parseLength(s[i]);
+                if (!l)
+                    return null;
+                r.push(l);
+            }
+
+            return r;
+        },
+        function (doc, parent, element, attr) {
+
+            var padding;
+
+            /* TODO: make sure we are in region */
+
+            /*
+             * expand padding shortcuts to
+             * [before, end, after, start]
+             *
+             */
+
+            if (attr.length === 1) {
+
+                padding = [attr[0], attr[0], attr[0], attr[0]];
+
+            } else if (attr.length === 2) {
+
+                padding = [attr[0], attr[1], attr[0], attr[1]];
+
+            } else if (attr.length === 3) {
+
+                padding = [attr[0], attr[1], attr[2], attr[1]];
+
+            } else if (attr.length === 4) {
+
+                padding = [attr[0], attr[1], attr[2], attr[3]];
+
+            } else {
+
+                return null;
+
+            }
+
+            /* TODO: take into account tts:direction */
+
+            /*
+             * transform [before, end, after, start] according to writingMode to
+             * [top,left,bottom,right]
+             *
+             */
+
+            var dir = element.styleAttrs[imscStyles.byName.writingMode.qname];
+
+            if (dir === 'lrtb' || dir === 'lr') {
+
+                padding = [padding[0], padding[3], padding[2], padding[1]];
+
+            } else if (dir === 'rltb' || dir === 'rl') {
+
+                padding = [padding[0], padding[1], padding[2], padding[3]];
+
+            } else if (dir === 'tblr') {
+
+                padding = [padding[3], padding[0], padding[1], padding[2]];
+
+            } else if (dir === 'tbrl' || dir === 'tb') {
+
+                padding = [padding[3], padding[2], padding[1], padding[0]];
+
+            } else {
+
+                return null;
+
+            }
+
+            var out = [];
+
+            for (var i = 0; i < padding.length; i++) {
+
+                if (padding[i].value === 0) {
+
+                    out[i] = new imscUtils.ComputedLength(0, 0);
+
+                } else {
+
+                    out[i] = imscUtils.toComputedLength(
+                        padding[i].value,
+                        padding[i].unit,
                         element.styleAttrs[imscStyles.byName.fontSize.qname],
-                        null,
-                        doc.pxLength.w
-                        );
+                        i === 0 || i === 2 ? element.styleAttrs[imscStyles.byName.extent.qname].h : element.styleAttrs[imscStyles.byName.extent.qname].w,
+                        i === 0 || i === 2 ? doc.cellLength.h : doc.cellLength.w,
+                        i === 0 || i === 2 ? doc.pxLength.h : doc.pxLength.w
+                    );
 
-                    if (shadow.x_off === null)
+                    if (out[i] === null) return null;
+
+                }
+            }
+
+
+            return out;
+        }
+    ),
+    new StylingAttributeDefinition(
+        imscNames.ns_tts,
+        'position',
+        'top left',
+        ['region'],
+        false,
+        true,
+        function (str) {
+
+            return imscUtils.parsePosition(str);
+
+        },
+        function (doc, parent, element, attr) {
+            var h;
+            var w;
+
+            h = imscUtils.toComputedLength(
+                attr.v.offset.value,
+                attr.v.offset.unit,
+                null,
+                new imscUtils.ComputedLength(
+                    -element.styleAttrs[imscStyles.byName.extent.qname].h.rw,
+                    doc.dimensions.h.rh - element.styleAttrs[imscStyles.byName.extent.qname].h.rh
+                ),
+                null,
+                doc.pxLength.h
+            );
+
+            if (h === null) return null;
+
+
+            if (attr.v.edge === 'bottom') {
+
+                h = new imscUtils.ComputedLength(
+                    -h.rw - element.styleAttrs[imscStyles.byName.extent.qname].h.rw,
+                    doc.dimensions.h.rh - h.rh - element.styleAttrs[imscStyles.byName.extent.qname].h.rh
+                );
+
+            }
+
+            w = imscUtils.toComputedLength(
+                attr.h.offset.value,
+                attr.h.offset.unit,
+                null,
+                new imscUtils.ComputedLength(
+                    doc.dimensions.w.rw - element.styleAttrs[imscStyles.byName.extent.qname].w.rw,
+                    -element.styleAttrs[imscStyles.byName.extent.qname].w.rh
+                ),
+                null,
+                doc.pxLength.w
+            );
+
+            if (h === null) return null;
+
+            if (attr.h.edge === 'right') {
+
+                w = new imscUtils.ComputedLength(
+                    doc.dimensions.w.rw - w.rw - element.styleAttrs[imscStyles.byName.extent.qname].w.rw,
+                    -w.rh - element.styleAttrs[imscStyles.byName.extent.qname].w.rh
+                );
+
+            }
+
+            return {'h': h, 'w': w};
+        }
+    ),
+    new StylingAttributeDefinition(
+        imscNames.ns_tts,
+        'ruby',
+        'none',
+        ['span'],
+        false,
+        true,
+        function (str) {
+            return str;
+        },
+        null
+    ),
+    new StylingAttributeDefinition(
+        imscNames.ns_tts,
+        'rubyAlign',
+        'center',
+        ['span'],
+        true,
+        true,
+        function (str) {
+
+            if (!(str === 'center' || str === 'spaceAround')) {
+                return null;
+            }
+
+            return str;
+        },
+        null
+    ),
+    new StylingAttributeDefinition(
+        imscNames.ns_tts,
+        'rubyPosition',
+        'outside',
+        ['span'],
+        true,
+        true,
+        function (str) {
+            return str;
+        },
+        null
+    ),
+    new StylingAttributeDefinition(
+        imscNames.ns_tts,
+        'rubyReserve',
+        'none',
+        ['p'],
+        true,
+        true,
+        function (str) {
+            var s = str.split(' ');
+
+            var r = [null, null];
+
+            if (s.length === 0 || s.length > 2)
+                return null;
+
+            if (s[0] === 'none' ||
+                s[0] === 'both' ||
+                s[0] === 'after' ||
+                s[0] === 'before' ||
+                s[0] === 'outside') {
+
+                r[0] = s[0];
+
+            } else {
+
+                return null;
+
+            }
+
+            if (s.length === 2 && s[0] !== 'none') {
+
+                var l = imscUtils.parseLength(s[1]);
+
+                if (l) {
+
+                    r[1] = l;
+
+                } else {
+
+                    return null;
+
+                }
+
+            }
+
+
+            return r;
+        },
+        function (doc, parent, element, attr) {
+
+            if (attr[0] === 'none') {
+
+                return attr;
+
+            }
+
+            var fs = null;
+
+            if (attr[1] === null) {
+
+                fs = new imscUtils.ComputedLength(
+                    element.styleAttrs[imscStyles.byName.fontSize.qname].rw * 0.5,
+                    element.styleAttrs[imscStyles.byName.fontSize.qname].rh * 0.5
+                );
+
+            } else {
+
+                fs = imscUtils.toComputedLength(attr[1].value,
+                    attr[1].unit,
+                    element.styleAttrs[imscStyles.byName.fontSize.qname],
+                    element.styleAttrs[imscStyles.byName.fontSize.qname],
+                    doc.cellLength.h,
+                    doc.pxLength.h
+                );
+
+            }
+
+            if (fs === null) return null;
+
+            return [attr[0], fs];
+        }
+    ),
+    new StylingAttributeDefinition(
+        imscNames.ns_tts,
+        'showBackground',
+        'always',
+        ['region'],
+        false,
+        true,
+        function (str) {
+            return str;
+        },
+        null
+    ),
+    new StylingAttributeDefinition(
+        imscNames.ns_tts,
+        'textAlign',
+        'start',
+        ['p'],
+        true,
+        true,
+        function (str) {
+            return str;
+        },
+        function (doc, parent, element, attr) {
+            /* Section 7.16.9 of XSL */
+
+            if (attr === 'left') {
+
+                return 'start';
+
+            } else if (attr === 'right') {
+
+                return 'end';
+
+            } else {
+
+                return attr;
+
+            }
+        }
+    ),
+    new StylingAttributeDefinition(
+        imscNames.ns_tts,
+        'textCombine',
+        'none',
+        ['span'],
+        true,
+        true,
+        function (str) {
+            if (str === 'none' || str === 'all') {
+
+                return str;
+            }
+
+            return null;
+        },
+        null
+    ),
+    new StylingAttributeDefinition(
+        imscNames.ns_tts,
+        'textDecoration',
+        'none',
+        ['span'],
+        true,
+        true,
+        function (str) {
+            return str.split(' ');
+        },
+        null
+    ),
+    new StylingAttributeDefinition(
+        imscNames.ns_tts,
+        'textEmphasis',
+        'none',
+        ['span'],
+        true,
+        true,
+        function (str) {
+            var e = str.split(' ');
+
+            var rslt = {style: null, symbol: null, color: null, position: null};
+
+            for (var i = 0; i < e.length; i++) {
+
+                if (e[i] === 'none' || e[i] === 'auto') {
+
+                    rslt.style = e[i];
+
+                } else if (e[i] === 'filled' ||
+                    e[i] === 'open') {
+
+                    rslt.style = e[i];
+
+                } else if (e[i] === 'circle' ||
+                    e[i] === 'dot' ||
+                    e[i] === 'sesame') {
+
+                    rslt.symbol = e[i];
+
+                } else if (e[i] === 'current') {
+
+                    rslt.color = e[i];
+
+                } else if (e[i] === 'outside' || e[i] === 'before' || e[i] === 'after') {
+
+                    rslt.position = e[i];
+
+                } else {
+
+                    rslt.color = imscUtils.parseColor(e[i]);
+
+                    if (rslt.color === null)
                         return null;
 
-                    shadow.y_off = imscUtils.toComputedLength(
-                        attr[i][1].value,
-                        attr[i][1].unit,
+                }
+            }
+
+            if (rslt.style == null && rslt.symbol == null) {
+
+                rslt.style = 'auto';
+
+            } else {
+
+                rslt.symbol = rslt.symbol || 'circle';
+                rslt.style = rslt.style || 'filled';
+
+            }
+
+            rslt.position = rslt.position || 'outside';
+            rslt.color = rslt.color || 'current';
+
+            return rslt;
+        },
+        null
+    ),
+    new StylingAttributeDefinition(
+        imscNames.ns_tts,
+        'textOutline',
+        'none',
+        ['span'],
+        true,
+        true,
+        function (str) {
+
+            /*
+             * returns {c: <color>?, thichness: <length>} | "none"
+             *
+             */
+
+            if (str === 'none') {
+
+                return str;
+
+            } else {
+
+                var r = {};
+                var s = str.split(' ');
+                if (s.length === 0 || s.length > 2)
+                    return null;
+                var c = imscUtils.parseColor(s[0]);
+
+                r.color = c;
+
+                if (c !== null)
+                    s.shift();
+
+                if (s.length !== 1)
+                    return null;
+
+                var l = imscUtils.parseLength(s[0]);
+
+                if (!l)
+                    return null;
+
+                r.thickness = l;
+
+                return r;
+            }
+
+        },
+        function (doc, parent, element, attr) {
+
+            /*
+             * returns {color: <color>, thickness: <norm length>}
+             *
+             */
+
+            if (attr === 'none')
+                return attr;
+
+            var rslt = {};
+
+            if (attr.color === null) {
+
+                rslt.color = element.styleAttrs[imscStyles.byName.color.qname];
+
+            } else {
+
+                rslt.color = attr.color;
+
+            }
+
+            rslt.thickness = imscUtils.toComputedLength(
+                attr.thickness.value,
+                attr.thickness.unit,
+                element.styleAttrs[imscStyles.byName.fontSize.qname],
+                element.styleAttrs[imscStyles.byName.fontSize.qname],
+                doc.cellLength.h,
+                doc.pxLength.h
+            );
+
+            if (rslt.thickness === null)
+                return null;
+
+            return rslt;
+        }
+    ),
+    new StylingAttributeDefinition(
+        imscNames.ns_tts,
+        'textShadow',
+        'none',
+        ['span'],
+        true,
+        true,
+        imscUtils.parseTextShadow,
+        function (doc, parent, element, attr) {
+
+            /*
+             * returns [{x_off: <length>, y_off: <length>, b_radius: <length>, color: <color>}*] or "none"
+             *
+             */
+
+            if (attr === 'none')
+                return attr;
+
+            var r = [];
+
+            for (var i = 0; i < attr.length; i++) {
+
+                var shadow = {};
+
+                shadow.x_off = imscUtils.toComputedLength(
+                    attr[i][0].value,
+                    attr[i][0].unit,
+                    null,
+                    element.styleAttrs[imscStyles.byName.fontSize.qname],
+                    null,
+                    doc.pxLength.w
+                );
+
+                if (shadow.x_off === null)
+                    return null;
+
+                shadow.y_off = imscUtils.toComputedLength(
+                    attr[i][1].value,
+                    attr[i][1].unit,
+                    null,
+                    element.styleAttrs[imscStyles.byName.fontSize.qname],
+                    null,
+                    doc.pxLength.h
+                );
+
+                if (shadow.y_off === null)
+                    return null;
+
+                if (attr[i][2] === null) {
+
+                    shadow.b_radius = 0;
+
+                } else {
+
+                    shadow.b_radius = imscUtils.toComputedLength(
+                        attr[i][2].value,
+                        attr[i][2].unit,
                         null,
                         element.styleAttrs[imscStyles.byName.fontSize.qname],
                         null,
                         doc.pxLength.h
-                        );
+                    );
 
-                    if (shadow.y_off === null)
+                    if (shadow.b_radius === null)
                         return null;
-
-                    if (attr[i][2] === null) {
-
-                        shadow.b_radius = 0;
-
-                    } else {
-
-                        shadow.b_radius = imscUtils.toComputedLength(
-                            attr[i][2].value,
-                            attr[i][2].unit,
-                            null,
-                            element.styleAttrs[imscStyles.byName.fontSize.qname],
-                            null,
-                            doc.pxLength.h
-                            );
-
-                        if (shadow.b_radius === null)
-                            return null;
-
-                    }
-
-                    if (attr[i][3] === null) {
-
-                        shadow.color = element.styleAttrs[imscStyles.byName.color.qname];
-
-                    } else {
-
-                        shadow.color = attr[i][3];
-
-                    }
-
-                    r.push(shadow);
 
                 }
 
-                return r;
-            }
-        ),
-        new StylingAttributeDefinition(
-            imscNames.ns_tts,
-            "unicodeBidi",
-            "normal",
-            ['span', 'p'],
-            false,
-            true,
-            function (str) {
-                return str;
-            },
-            null
-            ),
-        new StylingAttributeDefinition(
-            imscNames.ns_tts,
-            "visibility",
-            "visible",
-            ['body', 'div', 'p', 'region', 'span'],
-            true,
-            true,
-            function (str) {
-                return str;
-            },
-            null
-            ),
-        new StylingAttributeDefinition(
-            imscNames.ns_tts,
-            "wrapOption",
-            "wrap",
-            ['span'],
-            true,
-            true,
-            function (str) {
-                return str;
-            },
-            null
-            ),
-        new StylingAttributeDefinition(
-            imscNames.ns_tts,
-            "writingMode",
-            "lrtb",
-            ['region'],
-            false,
-            true,
-            function (str) {
-                return str;
-            },
-            null
-            ),
-        new StylingAttributeDefinition(
-            imscNames.ns_tts,
-            "zIndex",
-            "auto",
-            ['region'],
-            false,
-            true,
-            function (str) {
+                if (attr[i][3] === null) {
 
-                var rslt;
-
-                if (str === 'auto') {
-
-                    rslt = str;
+                    shadow.color = element.styleAttrs[imscStyles.byName.color.qname];
 
                 } else {
 
-                    rslt = parseInt(str);
-
-                    if (isNaN(rslt)) {
-                        rslt = null;
-                    }
+                    shadow.color = attr[i][3];
 
                 }
 
-                return rslt;
-            },
-            null
-            ),
-        new StylingAttributeDefinition(
-            imscNames.ns_ebutts,
-            "linePadding",
-            "0c",
-            ['p'],
-            true,
-            false,
-            imscUtils.parseLength,
-            function (doc, parent, element, attr, context) {
-
-                return imscUtils.toComputedLength(attr.value, attr.unit, null, null, doc.cellLength.w, null);
+                r.push(shadow);
 
             }
-        ),
-        new StylingAttributeDefinition(
-            imscNames.ns_ebutts,
-            "multiRowAlign",
-            "auto",
-            ['p'],
-            true,
-            false,
-            function (str) {
-                return str;
-            },
-            null
-            ),
-        new StylingAttributeDefinition(
-            imscNames.ns_smpte,
-            "backgroundImage",
-            null,
-            ['div'],
-            false,
-            false,
-            function (str) {
-                return str;
-            },
-            null
-            ),
-        new StylingAttributeDefinition(
-            imscNames.ns_itts,
-            "forcedDisplay",
-            "false",
-            ['body', 'div', 'p', 'region', 'span'],
-            true,
-            true,
-            function (str) {
-                return str === 'true' ? true : false;
-            },
-            null
-            ),
-        new StylingAttributeDefinition(
-            imscNames.ns_itts,
-            "fillLineGap",
-            "false",
-            ['p'],
-            true,
-            true,
-            function (str) {
-                return str === 'true' ? true : false;
-            },
-            null
-            )
-    ];
 
-    /* TODO: allow null parse function */
+            return r;
+        }
+    ),
+    new StylingAttributeDefinition(
+        imscNames.ns_tts,
+        'unicodeBidi',
+        'normal',
+        ['span', 'p'],
+        false,
+        true,
+        function (str) {
+            return str;
+        },
+        null
+    ),
+    new StylingAttributeDefinition(
+        imscNames.ns_tts,
+        'visibility',
+        'visible',
+        ['body', 'div', 'p', 'region', 'span'],
+        true,
+        true,
+        function (str) {
+            return str;
+        },
+        null
+    ),
+    new StylingAttributeDefinition(
+        imscNames.ns_tts,
+        'wrapOption',
+        'wrap',
+        ['span'],
+        true,
+        true,
+        function (str) {
+            return str;
+        },
+        null
+    ),
+    new StylingAttributeDefinition(
+        imscNames.ns_tts,
+        'writingMode',
+        'lrtb',
+        ['region'],
+        false,
+        true,
+        function (str) {
+            return str;
+        },
+        null
+    ),
+    new StylingAttributeDefinition(
+        imscNames.ns_tts,
+        'zIndex',
+        'auto',
+        ['region'],
+        false,
+        true,
+        function (str) {
 
-    imscStyles.byQName = {};
-    for (var i in imscStyles.all) {
+            var rslt;
 
-        imscStyles.byQName[imscStyles.all[i].qname] = imscStyles.all[i];
-    }
+            if (str === 'auto') {
 
-    imscStyles.byName = {};
-    for (var j in imscStyles.all) {
+                rslt = str;
 
-        imscStyles.byName[imscStyles.all[j].name] = imscStyles.all[j];
-    }
+            } else {
 
+                rslt = parseInt(str);
 
-})(typeof exports === 'undefined' ? this.imscStyles = {} : exports,
-    typeof imscNames === 'undefined' ? require("./names") : imscNames,
-    typeof imscUtils === 'undefined' ? require("./utils") : imscUtils);
+                if (isNaN(rslt)) {
+                    rslt = null;
+                }
+
+            }
+
+            return rslt;
+        },
+        null
+    ),
+    new StylingAttributeDefinition(
+        imscNames.ns_ebutts,
+        'linePadding',
+        '0c',
+        ['p'],
+        true,
+        false,
+        imscUtils.parseLength,
+        function (doc, parent, element, attr) {
+
+            return imscUtils.toComputedLength(attr.value, attr.unit, null, null, doc.cellLength.w, null);
+
+        }
+    ),
+    new StylingAttributeDefinition(
+        imscNames.ns_ebutts,
+        'multiRowAlign',
+        'auto',
+        ['p'],
+        true,
+        false,
+        function (str) {
+            return str;
+        },
+        null
+    ),
+    new StylingAttributeDefinition(
+        imscNames.ns_smpte,
+        'backgroundImage',
+        null,
+        ['div'],
+        false,
+        false,
+        function (str) {
+            return str;
+        },
+        null
+    ),
+    new StylingAttributeDefinition(
+        imscNames.ns_itts,
+        'forcedDisplay',
+        'false',
+        ['body', 'div', 'p', 'region', 'span'],
+        true,
+        true,
+        function (str) {
+            return str === 'true' ? true : false;
+        },
+        null
+    ),
+    new StylingAttributeDefinition(
+        imscNames.ns_itts,
+        'fillLineGap',
+        'false',
+        ['p'],
+        true,
+        true,
+        function (str) {
+            return str === 'true';
+        },
+        null
+    )
+];
+
+/* TODO: allow null parse function */
+
+imscStyles.byQName = {};
+for (var i in imscStyles.all) {
+
+    imscStyles.byQName[imscStyles.all[i].qname] = imscStyles.all[i];
+}
+
+imscStyles.byName = {};
+for (var j in imscStyles.all) {
+
+    imscStyles.byName[imscStyles.all[j].name] = imscStyles.all[j];
+}
+
+module.exports = imscStyles;

--- a/src/main/js/utils.js
+++ b/src/main/js/utils.js
@@ -28,391 +28,378 @@
  * @module imscUtils
  */
 
-;
-(function (imscUtils) { // wrapper for non-node envs
+const imscUtils = {};
 
-    /* Documents the error handler interface */
+/*
+ * Parses a TTML color expression
+ *
+ */
 
-    /**
-     * @classdesc Generic interface for handling events. The interface exposes four
-     * methods:
-     * * <pre>info</pre>: unusual event that does not result in an inconsistent state
-     * * <pre>warn</pre>: unexpected event that should not result in an inconsistent state
-     * * <pre>error</pre>: unexpected event that may result in an inconsistent state
-     * * <pre>fatal</pre>: unexpected event that results in an inconsistent state
-     *   and termination of processing
-     * Each method takes a single <pre>string</pre> describing the event as argument,
-     * and returns a single <pre>boolean</pre>, which terminates processing if <pre>true</pre>.
-     *
-     * @name ErrorHandler
-     * @class
-     */
+const HEX_COLOR_RE = /#([0-9a-fA-F]{2})([0-9a-fA-F]{2})([0-9a-fA-F]{2})([0-9a-fA-F]{2})?/;
+const DEC_COLOR_RE = /rgb\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*\)/;
+const DEC_COLORA_RE = /rgba\(\s*(\d+),\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*\)/;
+const NAMED_COLOR = {
+    transparent: [0, 0, 0, 0],
+    black: [0, 0, 0, 255],
+    silver: [192, 192, 192, 255],
+    gray: [128, 128, 128, 255],
+    white: [255, 255, 255, 255],
+    maroon: [128, 0, 0, 255],
+    red: [255, 0, 0, 255],
+    purple: [128, 0, 128, 255],
+    fuchsia: [255, 0, 255, 255],
+    magenta: [255, 0, 255, 255],
+    green: [0, 128, 0, 255],
+    lime: [0, 255, 0, 255],
+    olive: [128, 128, 0, 255],
+    yellow: [255, 255, 0, 255],
+    navy: [0, 0, 128, 255],
+    blue: [0, 0, 255, 255],
+    teal: [0, 128, 128, 255],
+    aqua: [0, 255, 255, 255],
+    cyan: [0, 255, 255, 255]
+};
 
+imscUtils.parseColor = function (str) {
 
-    /*
-     * Parses a TTML color expression
-     * 
-     */
+    var m;
 
-    var HEX_COLOR_RE = /#([0-9a-fA-F]{2})([0-9a-fA-F]{2})([0-9a-fA-F]{2})([0-9a-fA-F]{2})?/;
-    var DEC_COLOR_RE = /rgb\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*\)/;
-    var DEC_COLORA_RE = /rgba\(\s*(\d+),\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*\)/;
-    var NAMED_COLOR = {
-        transparent: [0, 0, 0, 0],
-        black: [0, 0, 0, 255],
-        silver: [192, 192, 192, 255],
-        gray: [128, 128, 128, 255],
-        white: [255, 255, 255, 255],
-        maroon: [128, 0, 0, 255],
-        red: [255, 0, 0, 255],
-        purple: [128, 0, 128, 255],
-        fuchsia: [255, 0, 255, 255],
-        magenta: [255, 0, 255, 255],
-        green: [0, 128, 0, 255],
-        lime: [0, 255, 0, 255],
-        olive: [128, 128, 0, 255],
-        yellow: [255, 255, 0, 255],
-        navy: [0, 0, 128, 255],
-        blue: [0, 0, 255, 255],
-        teal: [0, 128, 128, 255],
-        aqua: [0, 255, 255, 255],
-        cyan: [0, 255, 255, 255]
-    };
+    var r = null;
 
-    imscUtils.parseColor = function (str) {
+    var nc = NAMED_COLOR[str.toLowerCase()];
 
-        var m;
-        
-        var r = null;
-        
-        var nc = NAMED_COLOR[str.toLowerCase()];
-        
-        if (nc !== undefined) {
+    if (nc !== undefined) {
 
-            r = nc;
+        r = nc;
 
-        } else if ((m = HEX_COLOR_RE.exec(str)) !== null) {
+    } else if ((m = HEX_COLOR_RE.exec(str)) !== null) {
 
-            r = [parseInt(m[1], 16),
-                parseInt(m[2], 16),
-                parseInt(m[3], 16),
-                (m[4] !== undefined ? parseInt(m[4], 16) : 255)];
-            
-        } else if ((m = DEC_COLOR_RE.exec(str)) !== null) {
+        r = [parseInt(m[1], 16),
+            parseInt(m[2], 16),
+            parseInt(m[3], 16),
+            (m[4] !== undefined ? parseInt(m[4], 16) : 255)];
 
-            r = [parseInt(m[1]),
-                parseInt(m[2]),
-                parseInt(m[3]),
-                255];
-            
-        } else if ((m = DEC_COLORA_RE.exec(str)) !== null) {
+    } else if ((m = DEC_COLOR_RE.exec(str)) !== null) {
 
-            r = [parseInt(m[1]),
-                parseInt(m[2]),
-                parseInt(m[3]),
-                parseInt(m[4])];
-            
-        }
+        r = [parseInt(m[1]),
+            parseInt(m[2]),
+            parseInt(m[3]),
+            255];
 
-        return r;
-    };
+    } else if ((m = DEC_COLORA_RE.exec(str)) !== null) {
 
-    var LENGTH_RE = /^((?:\+|\-)?\d*(?:\.\d+)?)(px|em|c|%|rh|rw)$/;
+        r = [parseInt(m[1]),
+            parseInt(m[2]),
+            parseInt(m[3]),
+            parseInt(m[4])];
 
-    imscUtils.parseLength = function (str) {
+    }
 
-        var m;
+    return r;
+};
 
-        var r = null;
+var LENGTH_RE = /^((?:[+-])?\d*(?:\.\d+)?)(px|em|c|%|rh|rw)$/;
 
-        if ((m = LENGTH_RE.exec(str)) !== null) {
+imscUtils.parseLength = function (str) {
 
-            r = {value: parseFloat(m[1]), unit: m[2]};
-        }
+    var m;
 
-        return r;
-    };
+    var r = null;
 
-    imscUtils.parseTextShadow = function (str) {
+    if ((m = LENGTH_RE.exec(str)) !== null) {
 
-        var shadows = str.match(/([^\(,\)]|\([^\)]+\))+/g);
-        
-        var r = [];
+        r = {value: parseFloat(m[1]), unit: m[2]};
+    }
 
-        for (var i = 0; i < shadows.length; i++) {
+    return r;
+};
 
-            var shadow = shadows[i].split(" ");
+imscUtils.parseTextShadow = function (str) {
 
-            if (shadow.length === 1 && shadow[0] === "none") {
+    var shadows = str.match(/([^(,)]|\([^)]+\))+/g);
 
-                return "none";
+    var r = [];
 
-            } else if (shadow.length > 1 && shadow.length < 5) {
+    for (var i = 0; i < shadows.length; i++) {
 
-                var out_shadow = [null, null, null, null];
+        var shadow = shadows[i].split(' ');
 
-                /* x offset */
+        if (shadow.length === 1 && shadow[0] === 'none') {
 
-                var l = imscUtils.parseLength(shadow.shift());
+            return 'none';
 
-                if (l === null)
-                    return null;
+        } else if (shadow.length > 1 && shadow.length < 5) {
 
-                out_shadow[0] = l;
+            var out_shadow = [null, null, null, null];
 
-                /* y offset */
+            /* x offset */
 
-                l = imscUtils.parseLength(shadow.shift());
+            var l = imscUtils.parseLength(shadow.shift());
 
-                if (l === null)
-                    return null;
+            if (l === null)
+                return null;
 
-                out_shadow[1] = l;
+            out_shadow[0] = l;
 
-                /* is there a third component */
+            /* y offset */
 
-                if (shadow.length === 0) {
-                    r.push(out_shadow);
-                    continue;
-                }
+            l = imscUtils.parseLength(shadow.shift());
 
-                l = imscUtils.parseLength(shadow[0]);
+            if (l === null)
+                return null;
 
-                if (l !== null) {
+            out_shadow[1] = l;
 
-                    out_shadow[2] = l;
+            /* is there a third component */
 
-                    shadow.shift();
-
-                }
-
-                if (shadow.length === 0) {
-                    r.push(out_shadow);
-                    continue;
-                }
-
-                var c = imscUtils.parseColor(shadow[0]);
-
-                if (c === null)
-                    return null;
-
-                out_shadow[3] = c;
-
+            if (shadow.length === 0) {
                 r.push(out_shadow);
+                continue;
             }
 
+            l = imscUtils.parseLength(shadow[0]);
+
+            if (l !== null) {
+
+                out_shadow[2] = l;
+
+                shadow.shift();
+
+            }
+
+            if (shadow.length === 0) {
+                r.push(out_shadow);
+                continue;
+            }
+
+            var c = imscUtils.parseColor(shadow[0]);
+
+            if (c === null)
+                return null;
+
+            out_shadow[3] = c;
+
+            r.push(out_shadow);
         }
 
-        return r;
+    }
+
+    return r;
+};
+
+
+imscUtils.parsePosition = function (str) {
+
+    /* see https://www.w3.org/TR/ttml2/#style-value-position */
+
+    var s = str.split(' ');
+
+    var isKeyword = function (str) {
+
+        return str === 'center' ||
+            str === 'left' ||
+            str === 'top' ||
+            str === 'bottom' ||
+            str === 'right';
+
     };
 
+    if (s.length > 4) {
 
-    imscUtils.parsePosition = function (str) {
+        return null;
 
-        /* see https://www.w3.org/TR/ttml2/#style-value-position */
+    }
 
-        var s = str.split(" ");
+    /* initial clean-up pass */
 
-        var isKeyword = function (str) {
+    for (var j = 0; j < s.length; j++) {
 
-            return str === "center" ||
-                    str === "left" ||
-                    str === "top" ||
-                    str === "bottom" ||
-                    str === "right";
+        if (!isKeyword(s[j])) {
 
-        };
+            var l = imscUtils.parseLength(s[j]);
 
-        if (s.length > 4) {
+            if (l === null)
+                return null;
 
-            return null;
-
+            s[j] = l;
         }
 
-        /* initial clean-up pass */
+    }
 
-        for (var j = 0 ; j < s.length; j++) {
+    /* position default */
 
-            if (!isKeyword(s[j])) {
+    var pos = {
+        h: {edge: 'left', offset: {value: 50, unit: '%'}},
+        v: {edge: 'top', offset: {value: 50, unit: '%'}}
+    };
 
-                var l = imscUtils.parseLength(s[j]);
+    /* update position */
 
-                if (l === null)
-                    return null;
+    for (var i = 0; i < s.length;) {
 
-                s[j] = l;
+        /* extract the current component */
+
+        var comp = s[i++];
+
+        if (isKeyword(comp)) {
+
+            /* we have a keyword */
+
+            var offset = {value: 0, unit: '%'};
+
+            /* peek at the next component */
+
+            if (s.length !== 2 && i < s.length && (!isKeyword(s[i]))) {
+
+                /* followed by an offset */
+
+                offset = s[i++];
+
             }
 
-        }
+            /* skip if center */
 
-        /* position default */
+            if (comp === 'right') {
 
-        var pos = {
-            h: {edge: "left", offset: {value: 50, unit: "%"}},
-            v: {edge: "top", offset: {value: 50, unit: "%"}}
-        };
+                pos.h.edge = comp;
 
-        /* update position */
+                pos.h.offset = offset;
 
-        for (var i = 0; i < s.length; ) {
+            } else if (comp === 'bottom') {
 
-            /* extract the current component */
+                pos.v.edge = comp;
 
-            var comp = s[i++];
-
-            if (isKeyword(comp)) {
-
-                /* we have a keyword */
-
-                var offset = {value: 0, unit: "%"};
-
-                /* peek at the next component */
-
-                if (s.length !== 2 && i < s.length && (!isKeyword(s[i]))) {
-
-                    /* followed by an offset */
-
-                    offset = s[i++];
-
-                }
-
-                /* skip if center */
-
-                if (comp === "right") {
-
-                    pos.h.edge = comp;
-
-                    pos.h.offset = offset;
-
-                } else if (comp === "bottom") {
-
-                    pos.v.edge = comp;
+                pos.v.offset = offset;
 
 
-                    pos.v.offset = offset;
+            } else if (comp === 'left') {
 
+                pos.h.offset = offset;
 
-                } else if (comp === "left") {
+            } else if (comp === 'top') {
 
-                    pos.h.offset = offset;
+                pos.v.offset = offset;
 
+            }
 
-                } else if (comp === "top") {
+        } else if (s.length === 1 || s.length === 2) {
 
-                    pos.v.offset = offset;
+            /* we have a bare value */
 
+            if (i === 1) {
 
-                }
+                /* assign it to left edge if first bare value */
 
-            } else if (s.length === 1 || s.length === 2) {
-
-                /* we have a bare value */
-
-                if (i === 1) {
-
-                    /* assign it to left edge if first bare value */
-
-                    pos.h.offset = comp;
-
-                } else {
-
-                    /* assign it to top edge if second bare value */
-
-                    pos.v.offset = comp;
-
-                }
+                pos.h.offset = comp;
 
             } else {
 
-                /* error condition */
+                /* assign it to top edge if second bare value */
 
-                return null;
+                pos.v.offset = comp;
 
             }
 
-        }
-
-        return pos;
-    };
-
-
-    imscUtils.ComputedLength = function (rw, rh) {
-        this.rw = rw;
-        this.rh = rh;
-    };
-
-    imscUtils.ComputedLength.prototype.toUsedLength = function (width, height) {
-        return width * this.rw + height * this.rh;
-    };
-
-    imscUtils.ComputedLength.prototype.isZero = function () {
-        return this.rw === 0 && this.rh === 0;
-    };
-
-    /**
-     * Computes a specified length to a root container relative length
-     * 
-     * @param {number} lengthVal Length value to be computed
-     * @param {string} lengthUnit Units of the length value
-     * @param {number} emScale length of 1em, or null if em is not allowed
-     * @param {number} percentScale length to which , or null if perecentage is not allowed
-     * @param {number} cellScale length of 1c, or null if c is not allowed
-     * @param {number} pxScale length of 1px, or null if px is not allowed
-     * @param {number} direction 0 if the length is computed in the horizontal direction, 1 if the length is computed in the vertical direction
-     * @return {number} Computed length
-     */
-    imscUtils.toComputedLength = function(lengthVal, lengthUnit, emLength, percentLength, cellLength, pxLength) {
-
-        if (lengthUnit === "%" && percentLength) {
-
-            return new imscUtils.ComputedLength(
-                    percentLength.rw * lengthVal / 100,
-                    percentLength.rh * lengthVal / 100
-                    );
-
-        } else if (lengthUnit === "em" && emLength) {
-
-            return new imscUtils.ComputedLength(
-                    emLength.rw * lengthVal,
-                    emLength.rh * lengthVal
-                    );
-
-        } else if (lengthUnit === "c" && cellLength) {
-
-            return new imscUtils.ComputedLength(
-                    lengthVal * cellLength.rw,
-                    lengthVal * cellLength.rh
-                    );
-
-        } else if (lengthUnit === "px" && pxLength) {
-
-            return new imscUtils.ComputedLength(
-                    lengthVal * pxLength.rw,
-                    lengthVal * pxLength.rh
-                    );
-
-        } else if (lengthUnit === "rh") {
-
-            return new imscUtils.ComputedLength(
-                    0,
-                    lengthVal / 100
-                    );
-
-        } else if (lengthUnit === "rw") {
-
-            return new imscUtils.ComputedLength(
-                    lengthVal / 100,
-                    0                    
-                    );
-
         } else {
+
+            /* error condition */
 
             return null;
 
         }
 
-    };
+    }
+
+    return pos;
+};
 
 
+imscUtils.ComputedLength = function (rw, rh) {
+    this.rw = rw;
+    this.rh = rh;
+};
 
-})(typeof exports === 'undefined' ? this.imscUtils = {} : exports);
+imscUtils.ComputedLength.prototype.toUsedLength = function (width, height) {
+    return width * this.rw + height * this.rh;
+};
+
+imscUtils.ComputedLength.prototype.isZero = function () {
+    return this.rw === 0 && this.rh === 0;
+};
+
+/**
+ * Computes a specified length to a root container relative length
+ *
+ * @param {number} lengthVal Length value to be computed
+ * @param {string} lengthUnit Units of the length value
+ * @param {number} emScale length of 1em, or null if em is not allowed
+ * @param {number} percentScale length to which , or null if perecentage is not allowed
+ * @param {number} cellScale length of 1c, or null if c is not allowed
+ * @param {number} pxScale length of 1px, or null if px is not allowed
+ * @param {number} direction 0 if the length is computed in the horizontal direction, 1 if the length is computed in the vertical direction
+ * @return {imscUtils.ComputedLength} Computed length
+ */
+imscUtils.toComputedLength = function (lengthVal, lengthUnit, emLength, percentLength, cellLength, pxLength) {
+
+    if (lengthUnit === '%' && percentLength) {
+
+        return new imscUtils.ComputedLength(
+            percentLength.rw * lengthVal / 100,
+            percentLength.rh * lengthVal / 100
+        );
+
+    } else if (lengthUnit === 'em' && emLength) {
+
+        return new imscUtils.ComputedLength(
+            emLength.rw * lengthVal,
+            emLength.rh * lengthVal
+        );
+
+    } else if (lengthUnit === 'c' && cellLength) {
+
+        return new imscUtils.ComputedLength(
+            lengthVal * cellLength.rw,
+            lengthVal * cellLength.rh
+        );
+
+    } else if (lengthUnit === 'px' && pxLength) {
+
+        return new imscUtils.ComputedLength(
+            lengthVal * pxLength.rw,
+            lengthVal * pxLength.rh
+        );
+
+    } else if (lengthUnit === 'rh') {
+
+        return new imscUtils.ComputedLength(
+            0,
+            lengthVal / 100
+        );
+
+    } else if (lengthUnit === 'rw') {
+
+        return new imscUtils.ComputedLength(
+            lengthVal / 100,
+            0
+        );
+
+    } else {
+
+        return null;
+
+    }
+
+};
+
+/**
+ * Wrapper for a direct call to Object.prototype.hasOwnProperty
+ *
+ * @param {unknown} maybeObject
+ * @param {string} property
+ * @returns {boolean}
+ */
+imscUtils.checkHasOwnProperty = (maybeObject, property) => {
+    return Object.prototype.hasOwnProperty.call(maybeObject, property);
+};
+
+module.exports = imscUtils;


### PR DESCRIPTION
This is an effort towards making this a Typescript library
* added Babel.js in the process (merged with browserify)
* preserved the compilation process
* replaced legacy JSHint with JSLint
* ensured that tests passes in QUnit
* extracted error reporting functions into a separate error.js file
* converted files into ESModules (the compilation target is still UMD though)
* preserved the way that sax is included in "imsc.all.*" build and excluded from "imsc.*" builds

**Breaking change!!**
If `imscDoc`, `imscHTML` was ever available in browser apart from global `imsc` namespace, they will be no longer.
That can be restored, but IMHO the price is too high compared to the tech debt that's left in code

I made sure that the unit-tests passes, but I am not entirely sure about renders. Please advise in this case to avoid breaking rendering of subtitles

--

Todos:
* extract IMSC objects classes into separate file
* move to the Typescript compiler (google-closure-compiler can still be used for minification)
* extract proper TS interfaces
* export types and extract to *.d.ts definition file
* fix potentially buggy code (replacing string with object in array, etc.)
* use ValueObject pattern (immutable IMSC classes with parameter injection via constructor, instead of "initFromNode")
* cloning process improvement