### PR TITLE
Bugfix - ruby+linepadding

### DIFF
--- a/src/main/js/html.js
+++ b/src/main/js/html.js
@@ -409,43 +409,51 @@
                 };
 
             } else {
+                if (isd_element.styleAttrs[imscStyles.byName.ruby.qname] === "text"){
+                    // don't split up the contents of ruby text elements - they do not get recombined.
+                    e.textContent = isd_element.text;
+                    e._isd_element = isd_element;
+                    if (te) {
+                        applyTextEmphasis(context, e, isd_element, te);
+                    };
+                } else {
 
-                // wrap characters in spans to find the line wrap locations
+                    // wrap characters in spans to find the line wrap locations
 
-                var cbuf = '';
+                    var cbuf = '';
 
-                for (var j = 0; j < isd_element.text.length; j++) {
+                    for (var j = 0; j < isd_element.text.length; j++) {
 
-                    cbuf += isd_element.text.charAt(j);
+                        cbuf += isd_element.text.charAt(j);
 
-                    var cc = isd_element.text.charCodeAt(j);
+                        var cc = isd_element.text.charCodeAt(j);
 
-                    if (cc < 0xD800 || cc > 0xDBFF || j === isd_element.text.length - 1) {
+                        if (cc < 0xD800 || cc > 0xDBFF || j === isd_element.text.length - 1) {
 
-                        /* wrap the character(s) in a span unless it is a high surrogate */
+                            /* wrap the character(s) in a span unless it is a high surrogate */
 
-                        var span = document.createElement("span");
+                            var span = document.createElement("span");
 
-                        span.textContent = cbuf;
+                            span.textContent = cbuf;
 
-                        /* apply textEmphasis */
-                        
-                        if (te) {
+                            /* apply textEmphasis */
+                            
+                            if (te) {
 
-                            applyTextEmphasis(context, span, isd_element, te);
+                                applyTextEmphasis(context, span, isd_element, te);
 
-                        };
-    
-                        e.appendChild(span);
+                            };
+        
+                            e.appendChild(span);
 
-                        cbuf = '';
+                            cbuf = '';
 
-                        //For the sake of merging these back together, record what isd element generated it.
-                        span._isd_element = isd_element;
+                            //For the sake of merging these back together, record what isd element generated it.
+                            span._isd_element = isd_element;
+                        }
+
                     }
-
                 }
-
             }
         }
 

--- a/src/main/js/html.js
+++ b/src/main/js/html.js
@@ -723,8 +723,16 @@
             if (l !== 0) {
 
                 var se = lineList[i].elements[lineList[i].start_elem];
+                // if inside rb, move to ruby
+                if (se.node.parentNode.nodeName === 'RB'){
+                    se = {node: se.node.parentNode.parentNode};
+                }
 
                 var ee = lineList[i].elements[lineList[i].end_elem];
+                // if inside rb, move to ruby
+                if (ee.node.parentNode.nodeName === 'RB'){
+                    ee = {node: ee.node.parentNode.parentNode};
+                }
 
                 if (se === ee) {
 

--- a/src/main/js/html.js
+++ b/src/main/js/html.js
@@ -634,6 +634,19 @@
 
                 }
             }
+
+            for (var el2 = 0; el2 < lineList[l].rbc.length; el2++) {
+                thisNode = lineList[l].rbc[el2];
+                ancestorBackgroundColor = getSpanAncestorColor(thisNode, clearTheseBackgrounds, false);
+
+                if (ancestorBackgroundColor) {
+
+                    thisNode.style.backgroundColor = ancestorBackgroundColor;
+
+                }
+            }
+
+
         }
 
         for (var bi = 0; bi < clearTheseBackgrounds.length; bi++) {


### PR DESCRIPTION
When applying line padding, if the start or end of line element is a span inside an RB element, then instead apply the padding to it's RUBY parent.
Not that this is more of a bandaid than a fix, as nested spans will have the same issue - start and end elements are only taken from leaf nodes, so any enclosing nodes may cut off the padding.

Also addresses background colors and ruby

Also avoids splitting rt text into spans (as they are not recombined).