### PR TITLE
Create `span` instead of `rb` elements

### DIFF
--- a/src/main/js/html.js
+++ b/src/main/js/html.js
@@ -648,7 +648,11 @@
 
         } else {
 
-            if (element.parentElement.nodeName === "SPAN") {
+            if (element.parentElement.nodeName === "SPAN"
+                element.parentElement.nodeName === "RUBY" ||
+                element.parentElement.nodeName === "RBC" ||
+                element.parentElement.nodeName === "RTC" ||
+                element.parentElement.nodeName === "RT") {
 
                 return getSpanAncestorColor(element.parentElement, ancestorList, true);
 

--- a/src/main/js/html.js
+++ b/src/main/js/html.js
@@ -648,7 +648,7 @@
 
         } else {
 
-            if (element.parentElement.nodeName === "SPAN"
+            if (element.parentElement.nodeName === "SPAN" ||
                 element.parentElement.nodeName === "RUBY" ||
                 element.parentElement.nodeName === "RBC" ||
                 element.parentElement.nodeName === "RTC" ||

--- a/src/main/js/html.js
+++ b/src/main/js/html.js
@@ -199,7 +199,7 @@
 
             } else if (isd_element.styleAttrs[imscStyles.byName.ruby.qname] === "base") {
 
-                e = document.createElement("rb");
+                e = document.createElement("span"); // rb element is deprecated in HTML
 
             } else if (isd_element.styleAttrs[imscStyles.byName.ruby.qname] === "text") {
 
@@ -876,7 +876,7 @@
 
             var ruby = document.createElement("ruby");
 
-            var rb = document.createElement("rb");
+            var rb = document.createElement("span");  // rb element is deprecated in HTML
             rb.textContent = "\u200B";
 
             ruby.appendChild(rb);


### PR DESCRIPTION
Closes #237. 

Empirically, it appears that browsers (Firefox and Chrome) do not implement layout on the currently deprecated `rb` element in the same way as on other elements. Specifically, they seem not to extend the padding rectangle to include the padded rectangles of child `span`s. Replacing the `rb` elements with `span` elements works around this. 

If at some point `rb` is un-deprecated, and this feature/bug of layout is improved, this change should be reverted.