### PR TITLE
Update README.md with latest - Release Links to UNPKG

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,9 +120,13 @@ RELEASES
 
 imscJS is released as an NPM package under [imsc](https://www.npmjs.com/package/imsc). The `dev` distribution tag indicates pre-releases.
 
-All builds are available on the [unpkg](https://unpkg.com/) CDN under the `dist` directory.
+All latest builds/dist are available on the [unpkg](https://unpkg.com/) CDN under the [`dist`](https://unpkg.com/browse/imsc/dist/) directory.
 
-EXAMPLE: https://unpkg.com/imsc@1.1.0-beta.2/dist/
+Available builds for the release 1.1.3 are: 
+* https://unpkg.com/browse/imsc@1.1.3/dist/imsc.all.min.js
+* https://unpkg.com/browse/imsc@1.1.3/dist/imsc.min.js
+* https://unpkg.com/browse/imsc@1.1.3/dist/imsc.all.debug.js
+* https://unpkg.com/browse/imsc@1.1.3/dist/imsc.debug.js
 
 
 

--- a/README.md
+++ b/README.md
@@ -120,13 +120,9 @@ RELEASES
 
 imscJS is released as an NPM package under [imsc](https://www.npmjs.com/package/imsc). The `dev` distribution tag indicates pre-releases.
 
-All latest builds/dist are available on the [unpkg](https://unpkg.com/) CDN under the [`dist`](https://unpkg.com/browse/imsc/dist/) directory.
+Builds/dist are available on the [unpkg](https://unpkg.com/) CDN under the [`dist`](https://unpkg.com/browse/imsc/dist/) directory.
 
-Available builds for the release 1.1.3 are: 
-* https://unpkg.com/browse/imsc@1.1.3/dist/imsc.all.min.js
-* https://unpkg.com/browse/imsc@1.1.3/dist/imsc.min.js
-* https://unpkg.com/browse/imsc@1.1.3/dist/imsc.all.debug.js
-* https://unpkg.com/browse/imsc@1.1.3/dist/imsc.debug.js
+To get access the latest builds, go the [release page](https://github.com/sandflow/imscJS/releases).
 
 
 
@@ -166,4 +162,4 @@ NOTABLE DIRECTORIES AND FILES
 
 * [dist](dist): Built libraries
 
-* [build/public_html](uild/public_html): Test web applications
+* [build/public_html](build/public_html): Test web applications

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ imscJS is released as an NPM package under [imsc](https://www.npmjs.com/package/
 
 Builds/dist are available on the [unpkg](https://unpkg.com/) CDN under the [`dist`](https://unpkg.com/browse/imsc/dist/) directory.
 
-To get access the latest builds, go the [release page](https://github.com/sandflow/imscJS/releases).
+To access the latest builds, please consult the [release page](https://github.com/sandflow/imscJS/releases).
 
 
 


### PR DESCRIPTION
unpkg will keep automatic redirect 
from https://unpkg.com/browse/imsc/dist/
to the latest published dist pakages, as of today 
it's at : https://unpkg.com/browse/imsc@1.1.3/dist/ 