### PR TITLE
Handle space characters in fontFamily within TTML Parsing

### DIFF
--- a/src/main/js/styles.js
+++ b/src/main/js/styles.js
@@ -193,6 +193,7 @@
                 var rslt = [];
 
                 for (var i = 0; i < ffs.length; i++) {
+                    ffs[i] = ffs[i].trim();
 
                     if (ffs[i].charAt(0) !== "'" && ffs[i].charAt(0) !== '"') {
 

--- a/src/test/resources/unit-tests/fontFamily.ttml
+++ b/src/test/resources/unit-tests/fontFamily.ttml
@@ -9,6 +9,8 @@ xmlns:tts="http://www.w3.org/ns/ttml#styling" ttp:cellResolution="1 1" tts:exten
 			<p tts:fontFamily="default">Maps 'default' generic family name to 'monospaceSerif' correctly.</p>
             <p tts:fontFamily="Arial,default">Maps 'default' value used as a fallback to 'monospaceSerif' correctly.</p>
             <p tts:fontFamily="Arial, default ">Maps 'default' value used as a fallback with spacing characters to 'monospaceSerif' correctly.</p>
+			<p tts:fontFamily="'My Test Font', default ">Fonts names wrapped in '' are preserved.</p>
+			<p tts:fontFamily='"My Test Font", default '>Fonts names wrapped in "" are preserved.</p>
 		</div>
 	</body>
 </tt>

--- a/src/test/resources/unit-tests/fontFamily.ttml
+++ b/src/test/resources/unit-tests/fontFamily.ttml
@@ -5,10 +5,10 @@ xmlns:tts="http://www.w3.org/ns/ttml#styling" ttp:cellResolution="1 1" tts:exten
 	<head>
 	</head>
 	<body>
-		<div>			
+		<div>
 			<p tts:fontFamily="default">Maps 'default' generic family name to 'monospaceSerif' correctly.</p>
-            <p tts:fontFamily="Arial,default">Maps 'default' value used as a fallback to 'monospaceSerif' correctly.</p>
-            <p tts:fontFamily="Arial, default ">Maps 'default' value used as a fallback with spacing characters to 'monospaceSerif' correctly.</p>
+			<p tts:fontFamily="Arial,default">Maps 'default' value used as a fallback to 'monospaceSerif' correctly.</p>
+			<p tts:fontFamily="Arial, default ">Maps 'default' value used as a fallback with spacing characters to 'monospaceSerif' correctly.</p>
 			<p tts:fontFamily="'My Test Font', default ">Fonts names wrapped in '' are preserved.</p>
 			<p tts:fontFamily='"My Test Font", default '>Fonts names wrapped in "" are preserved.</p>
 		</div>

--- a/src/test/resources/unit-tests/fontFamily.ttml
+++ b/src/test/resources/unit-tests/fontFamily.ttml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<tt xml:lang="en" xmlns="http://www.w3.org/ns/ttml" xmlns:ttm="http://www.w3.org/ns/ttml#metadata" 
+xmlns:ttp="http://www.w3.org/ns/ttml#parameter" ttp:profile="http://www.w3.org/ns/ttml/profile/imsc1/text"
+xmlns:tts="http://www.w3.org/ns/ttml#styling" ttp:cellResolution="1 1" tts:extent="100px 100px">
+	<head>
+	</head>
+	<body>
+		<div>			
+			<p tts:fontFamily="default">Maps 'default' generic family name to 'monospaceSerif' correctly.</p>
+            <p tts:fontFamily="Arial,default">Maps 'default' value used as a fallback to 'monospaceSerif' correctly.</p>
+            <p tts:fontFamily="Arial, default ">Maps 'default' value used as a fallback with spacing characters to 'monospaceSerif' correctly.</p>
+		</div>
+	</body>
+</tt>

--- a/src/test/webapp/js/unit-tests.js
+++ b/src/test/webapp/js/unit-tests.js
@@ -193,6 +193,18 @@ QUnit.test(
                     ["Arial", "monospaceSerif"],
                     "Maps 'default' value used as a fallback with spacing characters to 'monospaceSerif' correctly."
                 );
+
+                assert.deepEqual(
+                    doc.body.contents[0].contents[3].styleAttrs["http://www.w3.org/ns/ttml#styling fontFamily"],
+                    ["'My Test Font'", "monospaceSerif"],
+                    "Fonts names wrapped in '' are preserved."
+                );
+
+                assert.deepEqual(
+                    doc.body.contents[0].contents[4].styleAttrs["http://www.w3.org/ns/ttml#styling fontFamily"],
+                    ['"My Test Font"', "monospaceSerif"],
+                    'Fonts names wrapped in "" are preserved.'
+                );
             }
         );
 

--- a/src/test/webapp/js/unit-tests.js
+++ b/src/test/webapp/js/unit-tests.js
@@ -168,3 +168,33 @@ QUnit.test(
 
     }
 );
+
+QUnit.test(
+    "Font Family Parsing",
+    function (assert) {
+
+        return getIMSC1Document("unit-tests/fontFamily.ttml").then(
+            function (doc) {
+
+                assert.deepEqual(
+                    doc.body.contents[0].contents[0].styleAttrs["http://www.w3.org/ns/ttml#styling fontFamily"],
+                    ["monospaceSerif"],
+                    "Maps 'default' generic family name to 'monospaceSerif' correctly."
+                );
+
+                assert.deepEqual(
+                    doc.body.contents[0].contents[1].styleAttrs["http://www.w3.org/ns/ttml#styling fontFamily"],
+                    ["Arial", "monospaceSerif"],
+                    "Maps 'default' value used as a fallback to 'monospaceSerif' correctly."
+                );
+
+                assert.deepEqual(
+                    doc.body.contents[0].contents[2].styleAttrs["http://www.w3.org/ns/ttml#styling fontFamily"],
+                    ["Arial", "monospaceSerif"],
+                    "Maps 'default' value used as a fallback with spacing characters to 'monospaceSerif' correctly."
+                );
+            }
+        );
+
+    }
+);


### PR DESCRIPTION
Closes #250 
Similar to #245, the `default` generic font family was not being correctly mapped to `monospaceSerif` if there were stray spacing characters on either side of the word, i.e. ` default`.
A solution similar to #246 is implemented using `trim()` and a unit test is provided for sanity checking.