### PR TITLE
chore: update sax to 1.6.1 and refresh dev dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,17 +9,17 @@
             "version": "1.1.5",
             "license": "BSD-2-Clause",
             "dependencies": {
-                "sax": "1.2.1"
+                "sax": "^1.6.1"
             },
             "devDependencies": {
-                "@eslint/js": "^9.1.1",
-                "@rollup/plugin-commonjs": "^25.0.7",
-                "@rollup/plugin-node-resolve": "^15.2.3",
+                "@eslint/js": "^9.39.5",
+                "@rollup/plugin-commonjs": "^29.0.3",
+                "@rollup/plugin-node-resolve": "^16.0.3",
                 "@rollup/plugin-terser": "^1.0.0",
                 "@types/sax": "^1.2.7",
-                "eslint": "^9.1.1",
+                "eslint": "^9.39.5",
                 "filesaver.js-npm": "latest",
-                "globals": "^15.0.0",
+                "globals": "^17.11.0",
                 "grunt": "latest",
                 "grunt-contrib-clean": "latest",
                 "grunt-exec": "^3.0.0",
@@ -313,6 +313,9 @@
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -323,21 +326,22 @@
             }
         },
         "node_modules/@rollup/plugin-commonjs": {
-            "version": "25.0.8",
-            "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-25.0.8.tgz",
-            "integrity": "sha512-ZEZWTK5n6Qde0to4vS9Mr5x/0UZoqCxPVR9KRUjU4kA2sO7GEUn1fop0DAwpO6z0Nw/kJON9bDmSxdWxO/TT1A==",
+            "version": "29.0.3",
+            "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-29.0.3.tgz",
+            "integrity": "sha512-ZaOxZceP7SOUW7Lqw5IRVweSQYWaeIPnXIGLiB690EBA3FGJTO40EEr2L5yZplJWsgTCogILRSpcAe7+U0Otdg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@rollup/pluginutils": "^5.0.1",
                 "commondir": "^1.0.1",
                 "estree-walker": "^2.0.2",
-                "glob": "^8.0.3",
+                "fdir": "^6.2.0",
                 "is-reference": "1.2.1",
-                "magic-string": "^0.30.3"
+                "magic-string": "^0.30.3",
+                "picomatch": "^4.0.2"
             },
             "engines": {
-                "node": ">=14.0.0"
+                "node": ">=16.0.0 || 14 >= 14.17"
             },
             "peerDependencies": {
                 "rollup": "^2.68.0||^3.0.0||^4.0.0"
@@ -372,9 +376,9 @@
             }
         },
         "node_modules/@rollup/plugin-node-resolve": {
-            "version": "15.3.1",
-            "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-15.3.1.tgz",
-            "integrity": "sha512-tgg6b91pAybXHJQMAAwW9VuWBO6Thi+q7BCNARLwSqlmsHz0XYURtGvh/AuwSADXSI4h/2uHbs7s4FzlZDGSGA==",
+            "version": "16.0.3",
+            "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-16.0.3.tgz",
+            "integrity": "sha512-lUYM3UBGuM93CnMPG1YocWu7X802BrNF3jW2zny5gQyLQgRFJhV1Sq0Zi74+dh/6NBx1DxFC4b4GXg9wUCG5Qg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -534,6 +538,9 @@
                 "arm"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -548,6 +555,9 @@
                 "arm"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -562,6 +572,9 @@
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -576,6 +589,9 @@
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -590,6 +606,9 @@
                 "loong64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -604,6 +623,9 @@
                 "loong64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -618,6 +640,9 @@
                 "ppc64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -632,6 +657,9 @@
                 "ppc64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -646,6 +674,9 @@
                 "riscv64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -660,6 +691,9 @@
                 "riscv64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -674,6 +708,9 @@
                 "s390x"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -688,6 +725,9 @@
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -702,6 +742,9 @@
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1389,6 +1432,24 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/fdir": {
+            "version": "6.5.0",
+            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+            "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "peerDependencies": {
+                "picomatch": "^3 || ^4"
+            },
+            "peerDependenciesMeta": {
+                "picomatch": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/file-entry-cache": {
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -1579,27 +1640,6 @@
                 "node": ">=10"
             }
         },
-        "node_modules/glob": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
-            "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
-            "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^5.0.1",
-                "once": "^1.3.0"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
         "node_modules/glob-parent": {
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -1611,29 +1651,6 @@
             },
             "engines": {
                 "node": ">=10.13.0"
-            }
-        },
-        "node_modules/glob/node_modules/brace-expansion": {
-            "version": "2.1.4",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
-            "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^1.0.0"
-            }
-        },
-        "node_modules/glob/node_modules/minimatch": {
-            "version": "5.1.9",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
-            "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=10"
             }
         },
         "node_modules/global-modules": {
@@ -1682,9 +1699,9 @@
             }
         },
         "node_modules/globals": {
-            "version": "15.15.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-15.15.0.tgz",
-            "integrity": "sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==",
+            "version": "17.11.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-17.11.0.tgz",
+            "integrity": "sha512-Z2I8hM+PbJDXQDq3Icgpzv+mPdwr68iZUU9d5WW4FuXfDUQfkZaZuvjMv42/5crNyw154+9+VWXbYrUgDXbxNw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2971,10 +2988,13 @@
             "license": "MIT"
         },
         "node_modules/sax": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
-            "integrity": "sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA==",
-            "license": "ISC"
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.1.tgz",
+            "integrity": "sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==",
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": ">=11.0.0"
+            }
         },
         "node_modules/serialize-javascript": {
             "version": "7.1.1",

--- a/package.json
+++ b/package.json
@@ -37,17 +37,17 @@
         "test": "node --test ./src/test/js/*Test.js"
     },
     "dependencies": {
-        "sax": "1.2.1"
+        "sax": "^1.6.1"
     },
     "devDependencies": {
-        "@eslint/js": "^9.1.1",
-        "@rollup/plugin-commonjs": "^25.0.7",
-        "@rollup/plugin-node-resolve": "^15.2.3",
+        "@eslint/js": "^9.39.5",
+        "@rollup/plugin-commonjs": "^29.0.3",
+        "@rollup/plugin-node-resolve": "^16.0.3",
         "@rollup/plugin-terser": "^1.0.0",
         "@types/sax": "^1.2.7",
-        "eslint": "^9.1.1",
+        "eslint": "^9.39.5",
         "filesaver.js-npm": "latest",
-        "globals": "^15.0.0",
+        "globals": "^17.11.0",
         "grunt": "latest",
         "grunt-contrib-clean": "latest",
         "grunt-exec": "^3.0.0",


### PR DESCRIPTION
Dependency refresh for `integration/v2`. Two files: `package.json` and `package-lock.json`.

## What changed

- `sax` 1.2.1 (exact pin) to `^1.6.1`. The 1.4.2 through 1.6.1 releases harden the parser against hostile input: a fix for quadratic memory allocation on large CDATA blocks, limits on attribute count and depth, rejection of invalid code points, and stricter character reference validation in strict mode. imscJS parses in strict mode, so these apply.
- `@rollup/plugin-commonjs` ^25 to ^29, `@rollup/plugin-node-resolve` ^15 to ^16, `globals` ^15 to ^17. No config changes were needed.
- `eslint` and `@eslint/js` floors raised to the current 9.x releases.
- Lockfile regenerated. `npm audit` reports 0 vulnerabilities.

## Notes for review

- sax changed its license from ISC to BlueOak-1.0.0 starting with 1.4.2. BlueOak is permissive, but sax is bundled into `dist/imsc.min.js`, so the license mix of the published artifact changes. Flagging it here so the choice is deliberate.
- sax 1.6.x is stricter in strict mode. Documents with invalid character references or bad code points, which 1.2.1 tolerated, may now fail to parse. Well-formed TTML is unaffected.
- Two majors were left out on purpose. ESLint 10 adds `no-useless-assignment` to the recommended set, which flags two initializers in `isd.js` and `styles.js`; those fixes touch source and belong in their own change. TypeScript 7 removed `target: ES5` and `moduleResolution: node10`, both of which `tsconfig.json` uses, so that bump needs a tsconfig migration and changes the emitted code.

## Testing

`npm run lint`, `npm test` (7 of 7 pass, and the tests parse documents through sax), and `npm run build` (tsc compile plus rollup bundle) all pass with the new versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)